### PR TITLE
Refactor: 관리자 레이아웃 분리 및 대시보드 템플릿 정리

### DIFF
--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -1,45 +1,28 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorate="~{layout}">
-<head>
-    <meta charset="UTF-8">
-    <title>관리자 대시보드</title>
-</head>
+      layout:decorate="~{admin/layout-admin}">
 <body>
-<main layout:fragment="content" class="container" style="margin-top: 4rem;">
-    <div class="card grey lighten-4">
-        <div class="card-content">
-            <h4 class="center-align">🎬 관리자 페이지</h4>
-            <p class="center-align">환영합니다, 관리자님!</p>
-        </div>
-        <div class="card-action center-align">
-            <form th:action="@{/logout}" method="post">
-                <button type="submit" class="btn red lighten-1">로그아웃</button>
-            </form>
-        </div>
-    </div>
-
-    <div class="section" style="margin-top: 3rem;">
-        <div class="row">
-            <!-- 이후에 기능들 (회원 관리, 영화 등록 등) 들어갈 자리 -->
-            <div class="col s12 m6">
-                <div class="card">
-                    <div class="card-content">
-                        <span class="card-title">회원 관리</span>
-                        <p>회원 목록, 상세 조회, 삭제 등</p>
-                    </div>
+<section class="dashboard-section" layout:fragment="main-content">
+    <h4>🎬 Admin Dashboard</h4>
+    <p>Welcome, Admin!</p>
+    <div class="row">
+        <div class="col s12 m6">
+            <div class="card">
+                <div class="card-content">
+                    <span class="card-title">Edit</span>
+                    <p>Edit</p>
                 </div>
             </div>
-            <div class="col s12 m6">
-                <div class="card">
-                    <div class="card-content">
-                        <span class="card-title">영화 관리</span>
-                        <p>영화 추가, 수정, 태그 연결 등</p>
-                    </div>
+        </div>
+        <div class="col s12 m6">
+            <div class="card">
+                <div class="card-content">
+                    <span class="card-title">Edit</span>
+                    <p>Edit</p>
                 </div>
             </div>
         </div>
     </div>
-</main>
+</section>
 </body>
 </html>

--- a/backend/src/main/resources/templates/admin/layout-admin.html
+++ b/backend/src/main/resources/templates/admin/layout-admin.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout}">
+<head>
+    <meta charset="UTF-8">
+    <title>관리자 대시보드</title>
+    <style>
+        body {
+            background-color: #121212;
+            color: #bdbdbd;
+        }
+        .dashboard-flex {
+            display: flex;
+            background-color: #121212;
+            color: #bdbdbd;
+            margin: 0;
+        }
+        aside.dashboard-aside {
+            width: 250px;
+            background-color: #1e1e1e;
+            height: 86vh;
+            padding: 2rem;
+        }
+        .collapsible,
+        .collapsible > li,
+        .collapsible-header,
+        .collapsible-body,
+        .collapsible > li.active,
+        .collapsible > li.active .collapsible-body {
+            border: none !important;
+            box-shadow: none !important;
+        }
+        .collapsible-header, .collapsible-body {
+            padding-left: 0rem !important;
+            background-color: #1e1e1e !important;
+            color: #fafafa !important;
+        }
+        .collapsible-header {
+            display: flex !important;
+            justify-content: space-between !important;
+            align-items: center !important;
+            padding-left: 0.2rem !important;
+            padding-right: 1rem !important;
+        }
+        .collapsible-header i.material-icons {
+            margin-left: 0.5rem;
+            margin-right: 0 !important;
+        }
+        .collapsible-body {
+            padding-top: 0.3rem !important;
+            padding-bottom: 0.5rem !important;
+            padding-left: 1rem !important;
+            padding-right: 1rem !important;
+            border-top: none !important;
+            box-shadow: none !important;
+        }
+        .collapsible-body ul {
+            margin: 0;
+            padding: 0 0 0 1.2rem;
+            list-style: none;
+        }
+        .collapsible-body ul li {
+            margin-bottom: 1rem;
+        }
+        .collapsible-body ul li:last-child {
+            margin-bottom: 0;
+        }
+        section.dashboard-section {
+            flex-grow: 1;
+            padding: 2rem;
+        }
+    </style>
+</head>
+<body>
+<main layout:fragment="content" style="margin: 0; padding: 0;">
+    <div class="dashboard-flex">
+        <!-- 사이드바 -->
+        <aside class="dashboard-aside">
+            <h5 style="color: lightcoral;">Admin Menu</h5>
+            <ul class="collapsible">
+                <li>
+                    <a class="collapsible-header" href="/admin">Dashboard<i class="material-icons">bookmark</i></a>
+                </li>
+                <li>
+                    <div class="collapsible-header">User Management<i class="material-icons">expand_more</i></div>
+                    <div class="collapsible-body">
+                        <ul>
+                            <li><a href="/admin/users" style="color:white;">User List</a></li>
+                            <li><a href="/admin/users/detail" style="color:white;">User Details</a></li>
+                            <li><a href="/admin/users/delete" style="color:white;">Delete User</a></li>
+                        </ul>
+                    </div>
+                </li>
+                <li>
+                    <div class="collapsible-header">Movie Management<i class="material-icons">expand_more</i></div>
+                    <div class="collapsible-body">
+                        <ul>
+                            <li><a href="/admin/movies" style="color:white;">All Movies</a></li>
+                            <li><a href="/admin/movies/manual" style="color:white;">Manual Movie Registration</a></li>
+                            <li><a href="/admin/movies/edit" style="color:white;">Edit Movie Info</a></li>
+                            <li><a href="/admin/coming-soon" style="color:white;">Upcoming Releases</a></li>
+                        </ul>
+                    </div>
+                </li>
+                <li>
+                    <div class="collapsible-header">Tag Management<i class="material-icons">expand_more</i></div>
+                    <div class="collapsible-body">
+                        <ul>
+                            <li><a href="/admin/tags" style="color:white;">View Tags</a></li>
+                            <li><a href="/admin/tags/manual" style="color:white;">Manual Tag Registration</a></li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </aside>
+
+        <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                var elems = document.querySelectorAll('.collapsible');
+                M.Collapsible.init(elems);
+            });
+        </script>
+
+        <!-- 메인 콘텐츠 영역만 비워둠 -->
+        <section class="dashboard-section" layout:fragment="main-content"></section>
+    </div>
+</main>
+</body>
+</html>
+

--- a/backend/src/main/resources/templates/fragments.html
+++ b/backend/src/main/resources/templates/fragments.html
@@ -38,7 +38,13 @@
           <li><a href="/" class="white-text">Home</a></li>
           <li><a href="/search" class="white-text">Search</a></li>
           <li><a href="#" class="white-text">My Page</a></li>
-          <li><a href="/login" class="highlight">Login</a></li>
+          <!-- 로그인 여부에 따라 다른 메뉴 출력 -->
+          <th:block th:if="${#authorization.expression('isAuthenticated()')}">
+            <li><a href="#" id="logout" class="highlight">Logout</a></li>
+          </th:block>
+          <th:block th:unless="${#authorization.expression('isAuthenticated()')}">
+            <li><a th:href="@{/login}" class="highlight">Login</a></li>
+          </th:block>
         </ul>
       </div>
     </nav>
@@ -56,14 +62,12 @@
 
       logout.addEventListener('click', ev => {
         ev.preventDefault();
-        logoutForm.submit();
+        document.getElementById('logoutForm').submit();
       });
 
     })();
   </script>
 </th:block>
-
-
 
 <!-- footer -->
 <th:block th:fragment="frg_footer">
@@ -74,6 +78,6 @@
   </footer>
 </th:block>
 
-
 </body>
 </html>
+

--- a/backend/src/main/resources/templates/layout.html
+++ b/backend/src/main/resources/templates/layout.html
@@ -5,7 +5,7 @@
   <title>Title</title>
   <th:block th:replace="~{fragments :: frg_static}"/>
 </head>
-<body th:with="subject='thymleaf'">
+<body th:with="subject='thymeleaf'">
 
 <th:block th:replace="~{fragments :: frg_header}"/>
 


### PR DESCRIPTION
## 📌 과제 설명
관리자 페이지 대시보드의 레이아웃 구조를 정리하고, 공통 요소를 `layout-admin.html`로 분리하여 유지보수성을 개선했습니다.  
기존 `dashboard.html`은 핵심 콘텐츠만 남기고, 레이아웃 요소를 별도로 구성했습니다.

## 👩‍💻 요구 사항과 구현 내용
- `layout-admin.html` 생성  
  ↳ 관리자 화면 전용 레이아웃 정의 (사이드바 포함)  
- `dashboard.html` 구조 정리  
  ↳ 콘텐츠 부분만 유지, 공통 레이아웃은 `layout-admin`에 위임  
- `layout.html`, `fragments.html` 경미한 수정  
  ↳ 메뉴 렌더링 로직 보완 (로그인 여부, 스타일 등)
