### PR TITLE
feat: 회원가입 및 ID 찾기에 전화번호 필드 추가 fix: 회원가입 시 이메일 중복 사전 검증 로직 구현

### DIFF
--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/user/UserController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/user/UserController.java
@@ -59,8 +59,13 @@ public class UserController {
             model.addAttribute("signupRequestDto", signupRequestDto);
             model.addAttribute("codeSent", true);
             model.addAttribute("message", "인증 코드가 이메일로 전송되었습니다.");
+        } catch (IllegalArgumentException e) {
+            model.addAttribute("signupRequestDto", signupRequestDto);
+            model.addAttribute("codeSent", false);
+            model.addAttribute("error", e.getMessage());
         } catch (Exception e) {
             model.addAttribute("signupRequestDto", signupRequestDto);
+            model.addAttribute("codeSent", false);
             model.addAttribute("error", "인증 코드 전송에 실패했습니다: " + e.getMessage());
         }
         return "signup";

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/user/dto/FindIdRequestDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/user/dto/FindIdRequestDto.java
@@ -13,4 +13,5 @@ import lombok.Builder;
 @Builder
 public class FindIdRequestDto {
     private String name;
+    private String phoneNumber;
 } 

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/user/dto/SignupRequestDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/user/dto/SignupRequestDto.java
@@ -15,5 +15,6 @@ public class SignupRequestDto {
     private String email;
     private String password;
     private String name;
+    private String phoneNumber;
     private String confirmPassword;
 } 

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/user/repository/UserJpaRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/user/repository/UserJpaRepository.java
@@ -8,4 +8,5 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByEmail(String email);
     boolean existsByEmail(String email);
     Optional<UserEntity> findByName(String name);
+    Optional<UserEntity> findByNameAndPhoneNumber(String name, String phoneNumber);
 } 

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/user/service/EmailVerificationJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/user/service/EmailVerificationJpaService.java
@@ -4,6 +4,7 @@ import com.grepp.smartwatcha.app.model.user.dto.EmailVerificationRequestDto;
 import com.grepp.smartwatcha.app.model.user.dto.EmailCodeVerifyRequestDto;
 import com.grepp.smartwatcha.infra.jpa.entity.EmailVerificationEntity;
 import com.grepp.smartwatcha.app.model.user.repository.EmailVerificationJpaRepository;
+import com.grepp.smartwatcha.app.model.user.repository.UserJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
@@ -17,12 +18,17 @@ import java.util.Random;
 @RequiredArgsConstructor
 public class EmailVerificationJpaService {
     private final EmailVerificationJpaRepository emailVerificationRepository;
+    private final UserJpaRepository userJpaRepository;
     private final JavaMailSender mailSender;
 
     @Value("${app.email.verification.expire-minutes:10}")
     private int expireMinutes;
 
     public void sendVerificationCode(EmailVerificationRequestDto requestDto) {
+        if (userJpaRepository.existsByEmail(requestDto.getEmail())) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        }
+
         String code = generateCode();
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime expiredAt = now.plusMinutes(expireMinutes);

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/user/service/UserJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/user/service/UserJpaService.java
@@ -37,15 +37,16 @@ public class UserJpaService {
                 .email(requestDto.getEmail())
                 .password(passwordEncoder.encode(requestDto.getPassword()))
                 .name(requestDto.getName())
+                .phoneNumber(requestDto.getPhoneNumber())
                 .role(Role.USER)
                 .build();
         return userJpaRepository.save(user).getId();
     }
 
     public String findIdByName(FindIdRequestDto findIdRequestDto) {
-        return userJpaRepository.findByName(findIdRequestDto.getName())
+        return userJpaRepository.findByNameAndPhoneNumber(findIdRequestDto.getName(), findIdRequestDto.getPhoneNumber())
             .map(UserEntity::getEmail)
-            .orElseThrow(() -> new IllegalArgumentException("해당 이름으로 등록된 사용자가 없습니다."));
+            .orElseThrow(() -> new IllegalArgumentException("해당 정보로 등록된 사용자가 없습니다."));
     }
 
     public void sendPasswordResetCode(String email) {

--- a/backend/src/main/java/com/grepp/smartwatcha/infra/jpa/entity/UserEntity.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/infra/jpa/entity/UserEntity.java
@@ -27,6 +27,9 @@ public class UserEntity extends BaseEntity {
     @Column(nullable = false, length = 50)
     private String name;
 
+    @Column(nullable = false, length = 20)
+    private String phoneNumber;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false) // Role 이 반드시 부여되도록 수정
     private Role role;

--- a/backend/src/main/resources/templates/signup.html
+++ b/backend/src/main/resources/templates/signup.html
@@ -27,6 +27,10 @@
                                 <label for="email">이메일</label>
                             </div>
                             <div class="input-field">
+                                <input type="text" id="phoneNumber" name="phoneNumber" th:value="${signupRequestDto.phoneNumber}" required>
+                                <label for="phoneNumber">전화번호</label>
+                            </div>
+                            <div class="input-field">
                                 <input type="password" id="password" name="password" required>
                                 <label for="password">비밀번호</label>
                             </div>
@@ -44,6 +48,7 @@
                         <form th:action="@{/user/signup/verify}" method="post" th:if="${codeSent == true}">
                             <input type="hidden" name="name" th:value="${signupRequestDto.name}">
                             <input type="hidden" name="email" th:value="${signupRequestDto.email}">
+                            <input type="hidden" name="phoneNumber" th:value="${signupRequestDto.phoneNumber}">
                             <input type="hidden" name="password" th:value="${signupRequestDto.password}">
                             <input type="hidden" name="confirmPassword" th:value="${signupRequestDto.confirmPassword}">
                             <div class="input-field">

--- a/backend/src/main/resources/templates/user/find-id.html
+++ b/backend/src/main/resources/templates/user/find-id.html
@@ -1,38 +1,43 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org"
-      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+<html lang="en" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:th="http://www.thymeleaf.org"
       layout:decorate="~{layout}">
 <head>
     <meta charset="UTF-8">
-    <title>아이디 찾기</title>
+    <title>Find ID - SmartMovie</title>
 </head>
 <body>
-<main layout:fragment="content" class="container" style="margin-top: 5rem; max-width: 500px;">
-    <div class="card grey darken-4">
-        <div class="card-content">
-            <span class="card-title center-align highlight">아이디 찾기</span>
-
-            <div class="center-align" style="margin-top: 1rem;" th:if="${error}">
-                <span class="red-text text-lighten-2" th:text="${error}"></span>
-            </div>
-
-            <div class="center-align" style="margin-top: 1rem;" th:if="${foundEmail}">
-                <span class="green-text text-lighten-2">찾은 이메일: <span th:text="${foundEmail}"></span></span>
-            </div>
-
-            <form th:action="@{/user/find-id}" method="post">
-                <div class="input-field">
-                    <input type="text" id="name" name="name" required>
-                    <label for="name">이름</label>
+<main layout:fragment="content" style="min-height: 80vh; padding-top: 80px; padding-bottom: 80px;">
+    <div class="container">
+        <div class="row">
+            <div class="col s12 m6 offset-m3">
+                <div class="card" style="background-color: #1e1e1e; padding: 20px;">
+                    <div class="card-content white-text">
+                        <span class="card-title center-align" style="color: #e53935; margin-bottom: 30px;">아이디 찾기</span>
+                        <div th:if="${error}" class="center-align red-text" th:text="${error}"></div>
+                        <div th:if="${foundEmail}" class="center-align">
+                            <p>찾은 이메일: <span th:text="${foundEmail}" style="color: #e53935;"></span></p>
+                        </div>
+                        <form th:action="@{/user/find-id}" method="post" th:unless="${foundEmail}">
+                            <div class="input-field">
+                                <input type="text" id="name" name="name" required>
+                                <label for="name">이름</label>
+                            </div>
+                            <div class="input-field">
+                                <input type="text" id="phoneNumber" name="phoneNumber" required>
+                                <label for="phoneNumber">전화번호</label>
+                            </div>
+                            <div class="center-align">
+                                <button type="submit" class="btn waves-effect waves-light" style="background-color: #e53935;">
+                                    아이디 찾기
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                    <div class="card-action center-align">
+                        <a th:href="@{/login}" style="color: #e53935;">로그인 페이지로 돌아가기</a>
+                    </div>
                 </div>
-
-                <div class="center-align" style="margin-top: 2rem;">
-                    <button type="submit" class="btn red accent-2 waves-effect waves-light">아이디 찾기</button>
-                </div>
-            </form>
-
-            <div class="center-align" style="margin-top: 1rem;">
-                <a href="/login" class="btn-flat waves-effect waves-light" style="color: #e53935;">로그인으로 돌아가기</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
📌 과제 설명 

회원가입 전화번호 필드 추가 & ID 찾기 개선 & 이메일 중복 체크 개선

👩‍💻 요구 사항과 구현 내용 

1. Feat: 회원가입 시 전화번호 필드 추가
	•	UserEntity에 phoneNumber 필드 추가 (nullable = false, length = 20)
	•	SignupRequestDto에 phoneNumber 필드 추가
	•	signup.html에 전화번호 입력 필드 UI 반영
	•	UserJpaService의 회원가입 로직에서 전화번호 저장 처리

2. Feat: ID(이메일) 찾기 기능 개선
	•	FindIdRequestDto에 전화번호 필드 추가
	•	UserJpaRepository에 findByNameAndPhoneNumber 메서드 추가
	•	UserJpaService의 기존 findIdByName 메서드를 이름 + 전화번호로 조회하도록 변경
	•	find-id.html 템플릿에 전화번호 입력 폼 추가

3. Fix: 이메일 중복 체크 로직 개선
	•	EmailVerificationJpaService에 이메일 중복 여부 검증 로직 추가
	•	인증 코드 전송 전에 이메일 중복 여부를 선 체크하도록 로직 수정
	•	UserController에서 중복 이메일인 경우 예외 처리 및 메시지 반환
	•	중복된 이메일일 경우 인증코드 전송을 차단하고, 즉시 에러 메시지 제공
