### PR TITLE
feat: UserEntity에 추가된 전화번호 필드를 관리자 회원 상세 정보 화면에 반영

### DIFF
--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/dto/AdminUserListResponseDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/dto/AdminUserListResponseDto.java
@@ -15,6 +15,7 @@ public class AdminUserListResponseDto {
   private Long id;
   private String name;
   private String email;
+  private String phoneNumber;
   private LocalDateTime createdAt;
   private LocalDateTime modifiedAt;
   private Boolean activated;

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/mapper/AdminUserMapper.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/mapper/AdminUserMapper.java
@@ -12,6 +12,7 @@ public class AdminUserMapper {
         .id(user.getId())
         .name(user.getName())
         .email(user.getEmail())
+        .phoneNumber(user.getPhoneNumber())
         .createdAt(user.getCreatedAt())
         .modifiedAt(user.getModifiedAt())
         .activated(user.getActivated())

--- a/backend/src/main/resources/templates/admin/user/list.html
+++ b/backend/src/main/resources/templates/admin/user/list.html
@@ -216,8 +216,9 @@
             <div th:id="'userModal__' + ${user.id}" class="modal black-text" style="background-color: #424242;">
               <div class="modal-content">
                 <h5 th:text="'👤 ' + ${user.name}"style="color: white">User Info</h5>
-                <p><strong style="color: white">Email:</strong> <span th:text="${user.email}" style="color: white">email</span></p>
                 <p><strong style="color: white">Role:</strong> <span th:text="${user.role}" style="color: white">USER</span></p>
+                <p><strong style="color: white">Email:</strong> <span th:text="${user.email}" style="color: white">email</span></p>
+                <p><strong style="color: white">Phone Number:</strong> <span th:text="${user.phoneNumber}" style="color: white">email</span></p>
                 <p><strong style="color: white">Activated:</strong>
                   <span th:text="${user.activated == true ? 'Active' : 'Inactive'}"
                         th:classappend="${user.activated == true} ? 'green-text' : 'red-text'">Active</span>


### PR DESCRIPTION
## 📌 과제 설명
관리자 페이지에서 회원 상세 정보 조회 시 전화번호(PhoneNumber)를 확인할 수 있도록 기능을 추가했습니다.

## 👩‍💻 요구 사항과 구현 내용
- `UserEntity`에 추가된 `phoneNumber` 필드를 기반으로 관리자 페이지 상세 보기(`list.html`)에서 해당 정보 표시
- `AdminUserListResponseDto`에 `phoneNumber` 필드 추가
- `AdminUserMapper` 수정: `UserEntity` → `AdminUserListResponseDto` 변환 시 `phoneNumber` 포함


