### PR TITLE
feat: 이메일 인증 UX 개선 및 관리자 마이페이지 접근 제어 추가

### DIFF
--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/user/MyPageController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/user/MyPageController.java
@@ -20,6 +20,9 @@ public class MyPageController {
 
     @GetMapping
     public String myPage(@AuthenticationPrincipal CustomUserDetails userDetails, Model model) {
+        if (userDetails != null && userDetails.getRole() != null && userDetails.getRole().name().equals("ADMIN")) {
+            return "redirect:/admin";
+        }
         UserEntity user = userJpaService.findById(userDetails.getUser().getId());
         model.addAttribute("user", user);
         return "user/mypage";

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/user/UserController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/user/UserController.java
@@ -58,15 +58,14 @@ public class UserController {
             );
             model.addAttribute("signupRequestDto", signupRequestDto);
             model.addAttribute("codeSent", true);
-            model.addAttribute("message", "인증 코드가 이메일로 전송되었습니다.");
+            long remaining = emailVerificationJpaService.getRemainingCooldownTime(signupRequestDto.getEmail());
+            System.out.println("DEBUG remainingTime: " + remaining);
+            model.addAttribute("remainingTime", remaining);
         } catch (IllegalArgumentException e) {
             model.addAttribute("signupRequestDto", signupRequestDto);
-            model.addAttribute("codeSent", false);
-            model.addAttribute("error", e.getMessage());
-        } catch (Exception e) {
-            model.addAttribute("signupRequestDto", signupRequestDto);
-            model.addAttribute("codeSent", false);
-            model.addAttribute("error", "인증 코드 전송에 실패했습니다: " + e.getMessage());
+            model.addAttribute("codeSent", true); // 반드시 true로 고정
+            long remaining = emailVerificationJpaService.getRemainingCooldownTime(signupRequestDto.getEmail());
+            model.addAttribute("remainingTime", remaining);
         }
         return "signup";
     }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/user/service/EmailVerificationJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/user/service/EmailVerificationJpaService.java
@@ -12,6 +12,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Random;
 
 @Service
@@ -24,25 +25,54 @@ public class EmailVerificationJpaService {
     @Value("${app.email.verification.expire-minutes:10}")
     private int expireMinutes;
 
+    @Value("${app.email.verification.cooldown-seconds:60}")
+    private int cooldownSeconds;
+
     public void sendVerificationCode(EmailVerificationRequestDto requestDto) {
         if (userJpaRepository.existsByEmailAndActivatedIsTrue(requestDto.getEmail())) {
             throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
         }
 
+        // Check cooldown
+        emailVerificationRepository.findByEmail(requestDto.getEmail())
+            .ifPresent(entity -> {
+                LocalDateTime now = LocalDateTime.now();
+                long secondsSinceLastSent = ChronoUnit.SECONDS.between(entity.getLastSentAt(), now);
+                if (secondsSinceLastSent < cooldownSeconds) {
+                    throw new IllegalArgumentException(
+                        String.format("인증 코드는 %d초 후에 다시 전송할 수 있습니다. (%d초 남음)", 
+                            cooldownSeconds, cooldownSeconds - secondsSinceLastSent)
+                    );
+                }
+            });
+
         String code = generateCode();
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime expiredAt = now.plusMinutes(expireMinutes);
+        
         emailVerificationRepository.findByEmail(requestDto.getEmail())
                 .ifPresent(emailVerificationRepository::delete);
+                
         EmailVerificationEntity entity = EmailVerificationEntity.builder()
                 .email(requestDto.getEmail())
                 .code(code)
                 .createdAt(now)
                 .expiredAt(expiredAt)
+                .lastSentAt(now)
                 .verified(false)
                 .build();
         emailVerificationRepository.save(entity);
         sendEmail(requestDto.getEmail(), code);
+    }
+
+    public long getRemainingCooldownTime(String email) {
+        return emailVerificationRepository.findByEmail(email)
+            .map(entity -> {
+                LocalDateTime now = LocalDateTime.now();
+                long secondsSinceLastSent = ChronoUnit.SECONDS.between(entity.getLastSentAt(), now);
+                return Math.max(0, cooldownSeconds - secondsSinceLastSent);
+            })
+            .orElse(0L);
     }
 
     public boolean verifyCode(EmailCodeVerifyRequestDto requestDto) {

--- a/backend/src/main/java/com/grepp/smartwatcha/infra/jpa/entity/EmailVerificationEntity.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/infra/jpa/entity/EmailVerificationEntity.java
@@ -29,5 +29,8 @@ public class EmailVerificationEntity {
     @Column(nullable = false)
     private LocalDateTime expiredAt;
 
+    @Column(nullable = false, columnDefinition = "datetime(6) default CURRENT_TIMESTAMP")
+    private LocalDateTime lastSentAt;
+
     private boolean verified = false;
 }

--- a/backend/src/main/resources/templates/layout.html
+++ b/backend/src/main/resources/templates/layout.html
@@ -14,5 +14,6 @@
 </main>
 
 <th:block th:replace="~{fragments :: frg_footer}"/>
+<div layout:fragment="pageScripts"></div>
 </body>
 </html>

--- a/backend/src/main/resources/templates/signup.html
+++ b/backend/src/main/resources/templates/signup.html
@@ -5,6 +5,51 @@
 <head>
     <meta charset="UTF-8">
     <title>Sign Up - SmartMovie</title>
+    <style>
+        .input-field input[type=text],
+        .input-field input[type=email],
+        .input-field input[type=password],
+        .input-field input[type=tel] {
+            color: white;
+        }
+        .input-field label {
+            color: #9e9e9e;
+        }
+        .input-field input[type=text]:focus + label,
+        .input-field input[type=email]:focus + label,
+        .input-field input[type=password]:focus + label,
+        .input-field input[type=tel]:focus + label {
+            color: #e53935;
+        }
+        .input-field input[type=text]:focus,
+        .input-field input[type=email]:focus,
+        .input-field input[type=password]:focus,
+        .input-field input[type=tel]:focus {
+            border-bottom: 1px solid #e53935;
+            box-shadow: 0 1px 0 0 #e53935;
+        }
+        .resend-btn {
+            margin-left: 8px;
+            font-size: 0.8em;
+            padding: 0.5em 1em;
+            background: #444;
+            color: #fff;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        .resend-btn:disabled {
+            background: #222;
+            color: #888;
+            cursor: not-allowed;
+        }
+    </style>
+    <!-- 인증 코드 전송 시 팝업 -->
+    <script>
+    function showVerificationPopup() {
+        alert('메일로 전송된 인증코드 6자리를 입력해주세요.');
+    }
+    </script>
 </head>
 <body>
 <main layout:fragment="content" style="min-height: 80vh; padding-top: 80px; padding-bottom: 80px;">
@@ -13,11 +58,13 @@
             <div class="col s12 m6 offset-m3">
                 <div class="card" style="background-color: #1e1e1e; padding: 20px;">
                     <div class="card-content white-text">
-                        <span class="card-title center-align" style="color: #e53935; margin-bottom: 30px;">회원가입</span>
+                        <!-- 타이틀: codeSent 값에 따라 분기 -->
+                        <span class="card-title center-align" style="color: #e53935; margin-bottom: 30px;"
+                              th:text="${codeSent} ? '인증 코드 입력' : '회원가입'"></span>
                         <div th:if="${message}" class="center-align green-text" th:text="${message}"></div>
                         <div th:if="${error}" class="center-align red-text" th:text="${error}"></div>
                         <!-- 인증 코드 전송 전 -->
-                        <form th:action="@{/user/signup/send-code}" method="post" th:if="${codeSent == false}">
+                        <form th:action="@{/user/signup/send-code}" method="post" th:if="${codeSent == false}" id="sendCodeForm">
                             <div class="input-field">
                                 <input type="text" id="name" name="name" th:value="${signupRequestDto.name}" required>
                                 <label for="name">이름</label>
@@ -39,22 +86,39 @@
                                 <label for="confirmPassword">비밀번호 확인</label>
                             </div>
                             <div class="center-align">
-                                <button type="submit" class="btn waves-effect waves-light" style="background-color: #e53935;">
+                                <button type="submit" id="sendCodeBtn" class="btn waves-effect waves-light" style="background-color: #e53935;"
+                                        th:disabled="${remainingTime > 0}"
+                                        th:text="${remainingTime > 0 ? '재전송 (' + remainingTime + '초)' : '인증 코드 전송'}">
                                     인증 코드 전송
                                 </button>
                             </div>
                         </form>
+                        <!-- 인증 코드 발송 버튼 클릭 시 팝업 및 비활성화 처리 -->
+                        <script>
+                            document.addEventListener('DOMContentLoaded', function() {
+                                var sendCodeForm = document.getElementById('sendCodeForm');
+                                var sendCodeBtn = document.getElementById('sendCodeBtn');
+                                if (sendCodeForm && sendCodeBtn) {
+                                    sendCodeForm.addEventListener('submit', function(e) {
+                                        sendCodeBtn.disabled = true;
+                                        alert('메일로 전송된 인증코드 6자리를 입력해주세요.');
+                                    });
+                                }
+                            });
+                        </script>
+
                         <!-- 인증 코드 전송 후 -->
-                        <form th:action="@{/user/signup/verify}" method="post" th:if="${codeSent == true}">
+                        <form th:action="@{/user/signup/verify}" method="post" th:if="${codeSent == true}" id="verifyForm">
                             <input type="hidden" name="name" th:value="${signupRequestDto.name}">
                             <input type="hidden" name="email" th:value="${signupRequestDto.email}">
                             <input type="hidden" name="phoneNumber" th:value="${signupRequestDto.phoneNumber}">
                             <input type="hidden" name="password" th:value="${signupRequestDto.password}">
                             <input type="hidden" name="confirmPassword" th:value="${signupRequestDto.confirmPassword}">
-                            <div class="input-field">
-                                <input type="text" id="verificationCode" name="verificationCode" required>
-                                <label for="verificationCode">인증 코드</label>
+                            <div class="input-field" style="display: flex; align-items: center;">
+                                <input type="text" id="verificationCode" name="verificationCode" required style="flex: 1;">
+                                <button type="button" id="resendBtn" class="resend-btn" style="margin-left:8px;">재전송</button>
                             </div>
+                            <div style="text-align: left; color: #e53935; font-size: 0.9em; margin-bottom: 10px;" id="timerText"></div>
                             <div class="center-align">
                                 <button type="submit" class="btn waves-effect waves-light" style="background-color: #e53935;">
                                     인증 확인 및 회원가입
@@ -70,5 +134,49 @@
         </div>
     </div>
 </main>
+<div layout:fragment="pageScripts">
+<script th:inline="javascript">
+    var remainingTime = /*[[${remainingTime}]]*/ 0;
+    console.log("remainingTime:", remainingTime);
+    var resendBtn = document.getElementById('resendBtn');
+    var timerText = document.getElementById('timerText');
+    function updateTimer() {
+        if (remainingTime > 0) {
+            timerText.textContent = '재전송까지 남은 시간 : ' + remainingTime + '초';
+        } else {
+            timerText.textContent = '';
+        }
+        remainingTime--;
+    }
+    document.addEventListener('DOMContentLoaded', function() {
+        if (resendBtn && timerText) {
+            updateTimer();
+            var timerInterval = setInterval(function() {
+                updateTimer();
+                if (remainingTime < 0) clearInterval(timerInterval);
+            }, 1000);
+        }
+        resendBtn && resendBtn.addEventListener('click', function() {
+            if (remainingTime > 0) {
+                alert('잠시 뒤에 다시 시도해주세요');
+                return;
+            }
+            alert('인증 코드가 전송되었습니다. 메일을 확인해주세요.');
+            var form = document.createElement('form');
+            form.method = 'POST';
+            form.action = '/user/signup/send-code';
+            ['name','email','phoneNumber','password','confirmPassword'].forEach(function(field) {
+                var input = document.createElement('input');
+                input.type = 'hidden';
+                input.name = field;
+                input.value = document.getElementsByName(field)[0].value;
+                form.appendChild(input);
+            });
+            document.body.appendChild(form);
+            form.submit();
+        });
+    });
+</script>
+</div>
 </body>
 </html> 

--- a/backend/src/main/resources/templates/user/find-id.html
+++ b/backend/src/main/resources/templates/user/find-id.html
@@ -5,6 +5,30 @@
 <head>
     <meta charset="UTF-8">
     <title>Find ID - SmartMovie</title>
+    <style>
+        .input-field input[type=text],
+        .input-field input[type=email],
+        .input-field input[type=password],
+        .input-field input[type=tel] {
+            color: white;
+        }
+        .input-field label {
+            color: #9e9e9e;
+        }
+        .input-field input[type=text]:focus + label,
+        .input-field input[type=email]:focus + label,
+        .input-field input[type=password]:focus + label,
+        .input-field input[type=tel]:focus + label {
+            color: #e53935;
+        }
+        .input-field input[type=text]:focus,
+        .input-field input[type=email]:focus,
+        .input-field input[type=password]:focus,
+        .input-field input[type=tel]:focus {
+            border-bottom: 1px solid #e53935;
+            box-shadow: 0 1px 0 0 #e53935;
+        }
+    </style>
 </head>
 <body>
 <main layout:fragment="content" style="min-height: 80vh; padding-top: 80px; padding-bottom: 80px;">

--- a/backend/src/main/resources/templates/user/find-password.html
+++ b/backend/src/main/resources/templates/user/find-password.html
@@ -1,10 +1,34 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org"
-      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+<html lang="en" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:th="http://www.thymeleaf.org"
       layout:decorate="~{layout}">
 <head>
     <meta charset="UTF-8">
-    <title>비밀번호 찾기</title>
+    <title>Find Password - SmartMovie</title>
+    <style>
+        .input-field input[type=text],
+        .input-field input[type=email],
+        .input-field input[type=password],
+        .input-field input[type=tel] {
+            color: white;
+        }
+        .input-field label {
+            color: #9e9e9e;
+        }
+        .input-field input[type=text]:focus + label,
+        .input-field input[type=email]:focus + label,
+        .input-field input[type=password]:focus + label,
+        .input-field input[type=tel]:focus + label {
+            color: #e53935;
+        }
+        .input-field input[type=text]:focus,
+        .input-field input[type=email]:focus,
+        .input-field input[type=password]:focus,
+        .input-field input[type=tel]:focus {
+            border-bottom: 1px solid #e53935;
+            box-shadow: 0 1px 0 0 #e53935;
+        }
+    </style>
 </head>
 <body>
 <main layout:fragment="content" class="container" style="margin-top: 5rem; max-width: 500px;">

--- a/backend/src/main/resources/templates/user/login.html
+++ b/backend/src/main/resources/templates/user/login.html
@@ -5,6 +5,30 @@
 <head>
     <meta charset="UTF-8">
     <title>로그인</title>
+    <style>
+        .input-field input[type=text],
+        .input-field input[type=email],
+        .input-field input[type=password],
+        .input-field input[type=tel] {
+            color: white;
+        }
+        .input-field label {
+            color: #9e9e9e;
+        }
+        .input-field input[type=text]:focus + label,
+        .input-field input[type=email]:focus + label,
+        .input-field input[type=password]:focus + label,
+        .input-field input[type=tel]:focus + label {
+            color: #e53935;
+        }
+        .input-field input[type=text]:focus,
+        .input-field input[type=email]:focus,
+        .input-field input[type=password]:focus,
+        .input-field input[type=tel]:focus {
+            border-bottom: 1px solid #e53935;
+            box-shadow: 0 1px 0 0 #e53935;
+        }
+    </style>
 </head>
 <body>
 <main layout:fragment="content" class="container" style="margin-top: 5rem; max-width: 500px;">

--- a/backend/src/main/resources/templates/user/mypage.html
+++ b/backend/src/main/resources/templates/user/mypage.html
@@ -17,6 +17,28 @@
             color: #9e9e9e;
             margin-bottom: 20px;
         }
+        .input-field input[type=text],
+        .input-field input[type=email],
+        .input-field input[type=password],
+        .input-field input[type=tel] {
+            color: white;
+        }
+        .input-field label {
+            color: #9e9e9e;
+        }
+        .input-field input[type=text]:focus + label,
+        .input-field input[type=email]:focus + label,
+        .input-field input[type=password]:focus + label,
+        .input-field input[type=tel]:focus + label {
+            color: #e53935;
+        }
+        .input-field input[type=text]:focus,
+        .input-field input[type=email]:focus,
+        .input-field input[type=password]:focus,
+        .input-field input[type=tel]:focus {
+            border-bottom: 1px solid #e53935;
+            box-shadow: 0 1px 0 0 #e53935;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
📌 과제 설명 
이메일 인증 UX 개선 및 관리자 마이페이지 리디렉션 로직 추가를 반영했습니다.

👩‍💻 요구 사항과 구현 내용 
1. Feat : 이메일 인증 UX 개선
	•	인증 코드 전송 시 60초 쿨타임 적용 및 타이머 표시
	•	타이머는 1초 단위로 실시간 갱신됨
	•	쿨타임이 끝나면 재전송 버튼 활성화
	•	버튼 UX 개선 : 타이머 종료 후 버튼 클릭 시 안내 팝업 표시
	•	JS 코드가 정상 렌더링되도록 Thymeleaf fragment에 포함
	•	인증 코드 입력폼에서만 타이머/재전송 버튼 노출되도록 분리 처리
	•	서버에서 remainingTime 값을 전달받아 정확한 타이머 계산 처리
	•	콘솔 디버깅용 로그 추가

2. Refactor : 관리자 계정의 마이페이지 진입 제어
	•	/user/mypage 접근 시 현재 로그인한 사용자의 role이 ADMIN이면 → /admin으로 자동 리디렉션 처리
	•	일반 사용자는 기존처럼 마이페이지 정상 접근 가능
	•	권한에 따른 분기 처리로 UX 일관성과 보안성 향상

✅ PR 포인트
	•	이메일 인증 UX 전반을 직관적으로 개선하고 타이머 로직을 안정화했습니다.
	•	관리자 계정의 마이페이지 진입을 막고, /admin으로 유도하는 방식으로 접근 권한 로직을 명확히 분리했습니다.
