### PR TITLE
refactor: EmailVerificationEntity lastSentAt 컬럼 columnDefinition 제거

### DIFF
--- a/backend/src/main/java/com/grepp/smartwatcha/infra/jpa/entity/EmailVerificationEntity.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/infra/jpa/entity/EmailVerificationEntity.java
@@ -29,7 +29,7 @@ public class EmailVerificationEntity {
     @Column(nullable = false)
     private LocalDateTime expiredAt;
 
-    @Column(nullable = false, columnDefinition = "datetime(6) default CURRENT_TIMESTAMP")
+    @Column(nullable = false)
     private LocalDateTime lastSentAt;
 
     private boolean verified = false;


### PR DESCRIPTION
✅ 피드백 반영사항 

refactor: EmailVerificationEntity lastSentAt 컬럼 columnDefinition 제거

- lastSentAt 필드에서 columnDefinition 속성 제거
- DB 타입에 의존하지 않고 코드에서 LocalDateTime.now()로 값 세팅