### PR TITLE
feat: 인증코드 만료 시간 10분->1분 수정

### DIFF
--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/user/service/EmailVerificationJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/user/service/EmailVerificationJpaService.java
@@ -22,7 +22,7 @@ public class EmailVerificationJpaService {
     private final UserJpaRepository userJpaRepository;
     private final JavaMailSender mailSender;
 
-    @Value("${app.email.verification.expire-minutes:10}")
+    @Value("${app.email.verification.expire-minutes:1}")
     private int expireMinutes;
 
     @Value("${app.email.verification.cooldown-seconds:60}")
@@ -96,7 +96,7 @@ public class EmailVerificationJpaService {
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(to);
         message.setSubject("[스마트왓챠] 이메일 인증 코드 안내");
-        message.setText("인증 코드: " + code + "\n10분 이내에 입력해 주세요.");
+        message.setText("인증 코드: " + code + "\n1분 이내에 입력해 주세요.");
         mailSender.send(message);
     }
 } 


### PR DESCRIPTION
📌 과제 설명 
feat: 인증코드 만료 시간 10분->1분 수정

👩‍💻 구현 내용
- 이메일 인증 코드 만료 시간을 10분에서 1분으로 단축
- 재전송 대기 시간(1분)과 동일한 만료 시간 적용
- 이메일 안내 메시지 수정 ("10분" → "1분")

✅ PR 포인트
- 재전송 대기 시간과 만료 시간을 일치시켜 일관성 있는 UX 제공
- 인증 코드의 유효 시간을 단축하여 보안성 향상
