### PR TITLE
feat: 공개 예정 영화 비동기 병합 저장 기능 구현

### DIFF
--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/UpcomingSyncApiController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/UpcomingSyncApiController.java
@@ -1,0 +1,31 @@
+package com.grepp.smartwatcha.app.controller.api.admin.upcoming;
+
+import com.grepp.smartwatcha.app.controller.web.admin.upcoming.UpcomingMovieSyncScheduler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/movies/upcoming")
+public class UpcomingSyncApiController {
+  // 수동 전체 동기화 : 수동으로 TMDB 에서 공개 예정작을 가져와 DB에 저장
+
+  private final UpcomingMovieSyncScheduler scheduler;
+
+  @PostMapping("/sync-manual")
+  public String syncUpcomingManually() {
+    scheduler.syncAllUpcomingMovies();
+    return "✅ 수동 동기화 완료 (GET)";
+  }
+
+  @GetMapping("/sync-manual-test")
+  public String syncTest() {
+    scheduler.syncAllUpcomingMovies();
+    return "✅ 수동 동기화 (GET)";
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/api/UpcomingMovieApi.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/api/UpcomingMovieApi.java
@@ -1,0 +1,22 @@
+package com.grepp.smartwatcha.app.controller.api.admin.upcoming.api;
+
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingMovieUpcomingApiResponse;
+import com.grepp.smartwatcha.infra.config.FeignCommonConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+    name = "Upcoming-movie-api",
+    url = "https://api.themoviedb.org/3",
+    configuration = {FeignCommonConfig.class})
+public interface UpcomingMovieApi {
+
+  @GetMapping("/movie/upcoming")
+  UpcomingMovieUpcomingApiResponse getUpcomingMovies(
+      @RequestParam("api_key") String apiKey,
+      @RequestParam("language") String language,
+      @RequestParam("page") int page,
+      @RequestParam("region") String region
+  );
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/api/UpcomingMovieCreditApi.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/api/UpcomingMovieCreditApi.java
@@ -1,0 +1,22 @@
+package com.grepp.smartwatcha.app.controller.api.admin.upcoming.api;
+
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingMovieCreditApiResponse;
+import com.grepp.smartwatcha.infra.config.FeignCommonConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+    name = "tmdb-credit-api",
+    url = "https://api.themoviedb.org/3",
+    configuration = {FeignCommonConfig.class}
+)
+public interface UpcomingMovieCreditApi { // 배우,감독,작가 정보
+
+  @GetMapping("/movie/{movieId}/credits")
+  UpcomingMovieCreditApiResponse getCredits(
+      @PathVariable("movieId") Long movieId,
+      @RequestParam("api_key") String apiKey
+  );
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/api/UpcomingMovieDetailApi.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/api/UpcomingMovieDetailApi.java
@@ -1,0 +1,22 @@
+package com.grepp.smartwatcha.app.controller.api.admin.upcoming.api;
+
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingMovieDetailApiResponse;
+import com.grepp.smartwatcha.infra.config.FeignCommonConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+    name = "tmdb-detail-api",
+    url = "https://api.themoviedb.org/3",
+    configuration = {FeignCommonConfig.class}
+)
+public interface UpcomingMovieDetailApi { //상세 국가,제작 정보
+
+  @GetMapping("/movie/{movieId}")
+  UpcomingMovieDetailApiResponse getDetails(
+      @PathVariable("movieId") Long movieId,
+      @RequestParam("api_key") String apiKey
+  );
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/api/UpcomingMovieGenreApi.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/api/UpcomingMovieGenreApi.java
@@ -1,0 +1,18 @@
+package com.grepp.smartwatcha.app.controller.api.admin.upcoming.api;
+
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingMovieGenreApiResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+    name = "tmdb-genre-api",
+    url = "https://api.themoviedb.org/3")
+public interface UpcomingMovieGenreApi { // 장르
+
+  @GetMapping("/genre/movie/list")
+  UpcomingMovieGenreApiResponse getGenres(
+      @RequestParam("api_key") String apiKey,
+      @RequestParam("language") String language);
+
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/api/UpcomingMovieReleaseDateApi.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/api/UpcomingMovieReleaseDateApi.java
@@ -1,0 +1,22 @@
+package com.grepp.smartwatcha.app.controller.api.admin.upcoming.api;
+
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingMovieReleaseDateApiResponse;
+import com.grepp.smartwatcha.infra.config.FeignCommonConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+    name = "tmdb-release-api",
+    url = "https://api.themoviedb.org/3",
+    configuration = {FeignCommonConfig.class}
+)
+public interface UpcomingMovieReleaseDateApi { //관람등급 정보
+
+  @GetMapping("/movie/{movieId}/release_dates")
+  UpcomingMovieReleaseDateApiResponse getReleaseDates(
+      @PathVariable("movieId") Long movieId,
+      @RequestParam("api_key") String apiKey
+  );
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/payload/UpcomingMovieCreditApiResponse.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/payload/UpcomingMovieCreditApiResponse.java
@@ -1,0 +1,12 @@
+package com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload;
+
+import com.grepp.smartwatcha.app.model.admin.upcoming.dto.UpcomingMovieCastDto;
+import com.grepp.smartwatcha.app.model.admin.upcoming.dto.UpcomingMovieCrewDto;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class UpcomingMovieCreditApiResponse {
+  private List<UpcomingMovieCastDto> cast;
+  private List<UpcomingMovieCrewDto> crew;
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/payload/UpcomingMovieDetailApiResponse.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/payload/UpcomingMovieDetailApiResponse.java
@@ -1,0 +1,21 @@
+package com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class UpcomingMovieDetailApiResponse {
+  @JsonProperty("origin_language")
+  private String originLanguage;
+
+  @JsonProperty("production_countries")
+  private List<ProductionCountry> productionCountries;
+
+  @Data
+  public static class ProductionCountry {
+    @JsonProperty("iso_3166_1")
+    private String iso31661;
+    private String name;
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/payload/UpcomingMovieGenreApiResponse.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/payload/UpcomingMovieGenreApiResponse.java
@@ -1,0 +1,10 @@
+package com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload;
+
+import com.grepp.smartwatcha.app.model.admin.upcoming.dto.UpcomingMovieGenreDto;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class UpcomingMovieGenreApiResponse {
+  private List<UpcomingMovieGenreDto> genres;
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/payload/UpcomingMovieReleaseDateApiResponse.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/payload/UpcomingMovieReleaseDateApiResponse.java
@@ -1,0 +1,28 @@
+package com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class UpcomingMovieReleaseDateApiResponse {
+  private List<CountryReleaseDates> results;
+
+  @Data
+  public static class CountryReleaseDates {
+    private String iso_3166_1;
+    private List<ReleaseDateDetail> release_dates;
+  }
+
+  @Data
+  public static class ReleaseDateDetail {
+    @JsonProperty("certification")
+    private String certification;
+
+    @JsonProperty("type")
+    private Integer type;
+
+    @JsonProperty("release_date")
+    private String releaseDate;
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/payload/UpcomingMovieUpcomingApiResponse.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/admin/upcoming/payload/UpcomingMovieUpcomingApiResponse.java
@@ -1,0 +1,28 @@
+package com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.grepp.smartwatcha.app.model.admin.upcoming.dto.UpcomingMovieDto;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class UpcomingMovieUpcomingApiResponse {
+
+  private Dates dates;
+  private int page;
+
+  @JsonProperty("results")
+  private List<UpcomingMovieDto> movies;
+
+  @JsonProperty("total_results")
+  private int totalResults;
+
+  @JsonProperty("total_pages")
+  private int totalPages;
+
+  @Data
+  public static class Dates {
+    private String maximum;
+    private String minimum;
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/admin/upcoming/UpcomingMoviePageController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/admin/upcoming/UpcomingMoviePageController.java
@@ -1,0 +1,44 @@
+package com.grepp.smartwatcha.app.controller.web.admin.upcoming;
+
+import com.grepp.smartwatcha.app.model.admin.upcoming.repository.jpa.UpcomingMovieSyncTimeJpaRepository;
+import com.grepp.smartwatcha.app.model.admin.upcoming.service.jpa.UpcomingMovieSaveJpaService;
+import com.grepp.smartwatcha.infra.jpa.entity.MovieEntity;
+import com.grepp.smartwatcha.infra.jpa.entity.SyncTimeEntity;
+import com.grepp.smartwatcha.infra.response.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/admin/movies/upcoming")
+public class UpcomingMoviePageController { // DB 에서 공개예정작을 가져와 화면(movie.html)에 전달
+
+  private final UpcomingMovieSaveJpaService saveJpaService;
+  private final UpcomingMovieSyncTimeJpaRepository upcomingMovieSyncTimeJpaRepository;
+
+  @GetMapping
+  public String page(@RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "5") int size,
+      Model model) {
+
+    Pageable pageable = PageRequest.of(page, size, Sort.by(Direction.ASC, "releaseDate"));
+    Page<MovieEntity> moviePage = saveJpaService.getUpcomingMovies(pageable);
+
+    model.addAttribute("movies", moviePage.getContent());
+    model.addAttribute("pageResponse", new PageResponse("upcoming", moviePage, 5));
+    model.addAttribute("lastSyncTime", upcomingMovieSyncTimeJpaRepository.findByType("upcoming")
+        .map(SyncTimeEntity::getSyncTime)
+        .orElse(null));
+
+    return "/admin/movie/upcoming/movie";
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/admin/upcoming/UpcomingMovieSyncScheduler.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/admin/upcoming/UpcomingMovieSyncScheduler.java
@@ -1,0 +1,80 @@
+package com.grepp.smartwatcha.app.controller.web.admin.upcoming;
+
+import com.grepp.smartwatcha.app.model.admin.upcoming.dto.UpcomingMovieDto;
+import com.grepp.smartwatcha.app.model.admin.upcoming.service.common.UpcomingMovieFetchService;
+import com.grepp.smartwatcha.app.model.admin.upcoming.service.common.UpcomingMovieUnifiedSaveService;
+import com.grepp.smartwatcha.app.model.admin.upcoming.service.jpa.UpcomingMovieSyncTimeJpaService;
+import java.util.ArrayList;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UpcomingMovieSyncScheduler {
+
+  @Value("${tmdb.api.key}")
+  private String apiKey;
+
+  private final UpcomingMovieFetchService fetchService;
+  private final UpcomingMovieUnifiedSaveService saveService;
+  private final UpcomingMovieSyncTimeJpaService syncTimeService;
+
+  @Scheduled(cron = "0 0 0 ? * MON") // 매주 월요일 00:00 스케줄러 작동
+  public void syncAllUpcomingMovies() {
+    log.info("🕒 [공개 예정작 스케줄러] 동기화 시작");
+
+    List<UpcomingMovieDto> allMovies = fetchService.fetchUpcomingMovies();
+    int total = allMovies.size();
+    int success = 0;
+    int skipped = 0;
+    int failed = 0;
+
+    List<String> skippedTitles = new ArrayList<>();
+    List<String> skippedReasons = new ArrayList<>();
+
+    for (UpcomingMovieDto baseDto : allMovies) {
+      try {
+        UpcomingMovieDto enrichedDto = fetchService.buildEnrichedDto(baseDto, apiKey);
+        // enrich 후 releaseType 체크
+        Integer type = enrichedDto.getReleaseType();
+        if (type == null || !(type == 1 || type == 3 || type == 4)) {
+          skippedTitles.add(enrichedDto.getTitle());
+          skippedReasons.add("releaseType 조건 불일치 (type: " + type + ")");
+          skipped++;
+          continue;
+        }
+
+        if (!enrichedDto.getReleaseDateTime().toLocalDate().isAfter(LocalDate.now())) {
+          skippedTitles.add(enrichedDto.getTitle());
+          skippedReasons.add("ReleaseDate 조건 불일치 (date: " + enrichedDto.getReleaseDateTime().toLocalDate() + ")");
+          skipped++;
+          continue;
+        }
+        saveService.saveAll(enrichedDto);
+        success++;
+
+      } catch (Exception e) {
+        failed++;
+      }
+    }
+    syncTimeService.update("upcoming");
+
+    // 요약 로그
+    log.info("📊 [공개 예정작 동기화 요약]");
+    log.info("✅ 저장 성공: {}건", success);
+    log.info("⏭️ 스킵된 항목: {}건", skipped);
+    log.info("❌ 저장 실패: {}건", failed);
+    log.info("🎬 총 시도된 영화 수: {}건", total);
+
+    for (int i = 0; i < skippedTitles.size(); i++) {
+      log.info("⏭️ [{}] 스킵 사유: {}", skippedTitles.get(i), skippedReasons.get(i));
+    }
+
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/dto/UpcomingMovieCastDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/dto/UpcomingMovieCastDto.java
@@ -1,0 +1,9 @@
+package com.grepp.smartwatcha.app.model.admin.upcoming.dto;
+
+import lombok.Data;
+
+@Data
+public class UpcomingMovieCastDto {
+  private String name;
+  private int order;
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/dto/UpcomingMovieCrewDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/dto/UpcomingMovieCrewDto.java
@@ -1,0 +1,9 @@
+package com.grepp.smartwatcha.app.model.admin.upcoming.dto;
+
+import lombok.Data;
+
+@Data
+public class UpcomingMovieCrewDto {
+  private String name;
+  private String job;
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/dto/UpcomingMovieDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/dto/UpcomingMovieDto.java
@@ -1,0 +1,44 @@
+package com.grepp.smartwatcha.app.model.admin.upcoming.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class UpcomingMovieDto {
+  private Long id;
+  private String title;
+
+  @JsonProperty("release_date")
+  private String releaseDate;
+
+  @JsonProperty("poster_path")
+  private String posterPath;
+
+  private String overview;
+
+  @JsonProperty("original_language")
+  private String originalLanguage;
+
+  @JsonProperty("genre_ids")
+  private List<Integer> genreIds;
+
+  @JsonProperty("release_type")
+  private Integer releaseType;
+
+  //credits API
+  private String country;
+  private String certification;
+
+  //neo4j
+  private List<String> actorNames = new ArrayList<>();
+  private List<String> directorNames = new ArrayList<>();
+  private List<String> writerNames = new ArrayList<>();
+
+  public LocalDateTime getReleaseDateTime() {
+    return LocalDate.parse(releaseDate).atStartOfDay(); // 00:00
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/dto/UpcomingMovieGenreDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/dto/UpcomingMovieGenreDto.java
@@ -1,0 +1,9 @@
+package com.grepp.smartwatcha.app.model.admin.upcoming.dto;
+
+import lombok.Data;
+
+@Data
+public class UpcomingMovieGenreDto {
+  private Integer id;
+  private String name;
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/mapper/UpcomingMovieMapper.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/mapper/UpcomingMovieMapper.java
@@ -1,0 +1,61 @@
+package com.grepp.smartwatcha.app.model.admin.upcoming.mapper;
+
+import com.grepp.smartwatcha.app.model.admin.upcoming.dto.UpcomingMovieDto;
+import com.grepp.smartwatcha.app.model.admin.upcoming.service.neo4j.UpcomingMovieGenreFetchNeo4jService;
+import com.grepp.smartwatcha.infra.jpa.entity.MovieEntity;
+import com.grepp.smartwatcha.infra.neo4j.node.ActorNode;
+import com.grepp.smartwatcha.infra.neo4j.node.DirectorNode;
+import com.grepp.smartwatcha.infra.neo4j.node.GenreNode;
+import com.grepp.smartwatcha.infra.neo4j.node.MovieNode;
+import com.grepp.smartwatcha.infra.neo4j.node.WriterNode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UpcomingMovieMapper {
+
+  private final UpcomingMovieGenreFetchNeo4jService genreFetchService;
+
+  //mysql
+  public MovieEntity toJpaEntity(UpcomingMovieDto dto){
+    LocalDateTime releaseDateTime = parseDateWithDefaultTime(dto.getReleaseDate());
+
+
+    return MovieEntity.builder()
+        .id(dto.getId())
+        .title(dto.getTitle())
+        .poster(dto.getPosterPath())
+        .releaseDate(releaseDateTime)
+        .overview(dto.getOverview() == null || dto.getOverview().isBlank() ? null : dto.getOverview())
+        .country(dto.getCountry())
+        .isReleased(releaseDateTime.toLocalDate().isBefore(LocalDate.now()))
+        .certification(dto.getCertification())
+        .build();
+  }
+
+  // 시간 변환 로직
+  public LocalDateTime parseDateWithDefaultTime(String datestr){
+    return LocalDate.parse(datestr).atStartOfDay();
+  }
+
+  //neo4j
+  public MovieNode toNeo4jNode(
+    UpcomingMovieDto dto,
+    List<ActorNode> actors,
+    List<DirectorNode> directors,
+    List<WriterNode> writers,
+    List<GenreNode> genres
+  ){
+    MovieNode movie = new MovieNode(dto.getId(), dto.getTitle());
+    movie.setActors(actors);
+    movie.setDirectors(directors);
+    movie.setWriters(writers);
+    movie.setGenres(genres);
+
+    return movie;
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/repository/jpa/UpcomingMovieJpaRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/repository/jpa/UpcomingMovieJpaRepository.java
@@ -1,0 +1,14 @@
+package com.grepp.smartwatcha.app.model.admin.upcoming.repository.jpa;
+
+import com.grepp.smartwatcha.infra.jpa.entity.MovieEntity;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UpcomingMovieJpaRepository extends JpaRepository<MovieEntity, Long> {
+  boolean existsById(Long id);
+  Page<MovieEntity> findByIsReleasedFalseAndReleaseDateAfter(LocalDateTime now, Pageable pageable);
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/repository/jpa/UpcomingMovieSyncTimeJpaRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/repository/jpa/UpcomingMovieSyncTimeJpaRepository.java
@@ -1,0 +1,9 @@
+package com.grepp.smartwatcha.app.model.admin.upcoming.repository.jpa;
+
+import com.grepp.smartwatcha.infra.jpa.entity.SyncTimeEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UpcomingMovieSyncTimeJpaRepository extends JpaRepository<SyncTimeEntity, String> {
+  Optional<SyncTimeEntity> findByType(String time);
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/repository/neo4j/UpcomingMovieNeo4jRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/repository/neo4j/UpcomingMovieNeo4jRepository.java
@@ -1,0 +1,9 @@
+package com.grepp.smartwatcha.app.model.admin.upcoming.repository.neo4j;
+
+import com.grepp.smartwatcha.infra.neo4j.node.MovieNode;
+import java.util.Optional;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+public interface UpcomingMovieNeo4jRepository extends Neo4jRepository<MovieNode, Long> {
+  Optional<MovieNode> findById(Integer tmdbId);
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/service/common/UpcomingMovieAsyncFetchService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/service/common/UpcomingMovieAsyncFetchService.java
@@ -1,0 +1,38 @@
+package com.grepp.smartwatcha.app.model.admin.upcoming.service.common;
+
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.api.UpcomingMovieCreditApi;
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.api.UpcomingMovieDetailApi;
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.api.UpcomingMovieReleaseDateApi;
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingMovieCreditApiResponse;
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingMovieDetailApiResponse;
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingMovieReleaseDateApiResponse;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpcomingMovieAsyncFetchService {
+
+  //비동기 병렬 호출 서비스(실제 병렬 호출을 수행하는 비동기 서비스)
+  private final UpcomingMovieCreditApi creditApi;
+  private final UpcomingMovieReleaseDateApi releaseDateApi;
+  private final UpcomingMovieDetailApi detailApi;
+
+  @Async
+  public CompletableFuture<UpcomingMovieCreditApiResponse> fetchCredits(Long movieId, String apiKey) {
+    return CompletableFuture.completedFuture(creditApi.getCredits(movieId, apiKey));
+  }
+
+  @Async
+  public CompletableFuture<UpcomingMovieReleaseDateApiResponse> fetchReleaseDates(Long movieId,
+      String apiKey) {
+    return CompletableFuture.completedFuture(releaseDateApi.getReleaseDates(movieId, apiKey));
+  }
+
+  @Async
+  public CompletableFuture<UpcomingMovieDetailApiResponse> fetchDetails(Long movieId, String apiKey) {
+    return CompletableFuture.completedFuture(detailApi.getDetails(movieId, apiKey));
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/service/common/UpcomingMovieDetailEnricher.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/service/common/UpcomingMovieDetailEnricher.java
@@ -1,0 +1,79 @@
+package com.grepp.smartwatcha.app.model.admin.upcoming.service.common;
+
+import com.grepp.smartwatcha.app.model.admin.upcoming.dto.UpcomingMovieCastDto;
+import com.grepp.smartwatcha.app.model.admin.upcoming.dto.UpcomingMovieCrewDto;
+import com.grepp.smartwatcha.app.model.admin.upcoming.dto.UpcomingMovieDto;
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingMovieCreditApiResponse;
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingMovieDetailApiResponse;
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingMovieReleaseDateApiResponse;
+import java.util.Comparator;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class UpcomingMovieDetailEnricher {
+
+  public void enrichCredits(UpcomingMovieDto dto, UpcomingMovieCreditApiResponse credits) {
+    List<String> actorNames = credits.getCast().stream()
+        .sorted(Comparator.comparingInt(UpcomingMovieCastDto::getOrder))
+        .limit(5)
+        .map(UpcomingMovieCastDto::getName)
+        .toList();
+    dto.setActorNames(actorNames);
+
+    List<String> directorNames = credits.getCrew().stream()
+        .filter(crew -> "Director".equalsIgnoreCase(crew.getJob()))
+        .map(UpcomingMovieCrewDto::getName)
+        .distinct()
+        .toList();
+    dto.setDirectorNames(directorNames);
+
+    List<String> writerNames = credits.getCrew().stream()
+        .filter(crew -> "Writer".equalsIgnoreCase(crew.getJob()) || "Screenplay".equalsIgnoreCase(
+            crew.getJob()))
+        .map(UpcomingMovieCrewDto::getName)
+        .distinct()
+        .toList();
+    dto.setWriterNames(writerNames);
+  }
+
+  public void enrichCertification(UpcomingMovieDto dto,
+      UpcomingMovieReleaseDateApiResponse releaseData) {
+    if (releaseData == null || releaseData.getResults() == null) {
+      System.out.println("releaseData 또는 results 없음");
+      return;
+    }
+
+    // releaseType 먼저 설정
+    releaseData.getResults().stream()
+        .filter(r -> "US".equals(r.getIso_3166_1()))
+        .flatMap(r -> r.getRelease_dates().stream())
+        .filter(rd -> rd.getType() != null)
+        .sorted(Comparator.comparing(
+            UpcomingMovieReleaseDateApiResponse.ReleaseDateDetail::getReleaseDate))
+        .findFirst()
+        .ifPresent(rd -> dto.setReleaseType(rd.getType()));
+
+    // certification 설정
+    releaseData.getResults().stream()
+        .filter(r -> "US".equals(r.getIso_3166_1()))
+        .flatMap(r -> r.getRelease_dates().stream())
+        .filter(rd -> rd.getCertification() != null && !rd.getCertification().isBlank())
+        .sorted(Comparator.comparing(
+            UpcomingMovieReleaseDateApiResponse.ReleaseDateDetail::getReleaseDate))
+        .findFirst()
+        .ifPresent(rd -> {
+          dto.setCertification(rd.getCertification());
+        });
+  }
+
+    public void enrichCountry (UpcomingMovieDto dto, UpcomingMovieDetailApiResponse detail){
+      if (detail.getProductionCountries() != null && !detail.getProductionCountries().isEmpty()) {
+        String countryCode = detail.getProductionCountries().get(0).getIso31661();
+        dto.setCountry(countryCode);
+
+      }
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/service/common/UpcomingMovieFetchService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/service/common/UpcomingMovieFetchService.java
@@ -1,0 +1,63 @@
+package com.grepp.smartwatcha.app.model.admin.upcoming.service.common;
+
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.api.UpcomingMovieApi;
+import com.grepp.smartwatcha.app.model.admin.upcoming.dto.UpcomingMovieDto;
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingMovieCreditApiResponse;
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingMovieDetailApiResponse;
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingMovieReleaseDateApiResponse;
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingMovieUpcomingApiResponse;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpcomingMovieFetchService { // "영화 1편"의 정보를 한 DTO 에 채워주는 흐름 관리용 서비스
+
+  private final UpcomingMovieAsyncFetchService asyncService;
+  private final UpcomingMovieDetailEnricher dtoEnricher;
+  private final UpcomingMovieApi upcomingMovieApi;
+
+  @Value("${tmdb.api.key}")
+  private String apiKey;
+
+  public UpcomingMovieDto buildEnrichedDto(UpcomingMovieDto baseDto, String apiKey) throws ExecutionException, InterruptedException {
+    Long movieId = baseDto.getId();
+
+    // 병렬 호출 시작
+    CompletableFuture<UpcomingMovieCreditApiResponse> creditsFuture = asyncService.fetchCredits(movieId, apiKey);
+    CompletableFuture<UpcomingMovieReleaseDateApiResponse> releaseFuture = asyncService.fetchReleaseDates(movieId, apiKey);
+    CompletableFuture<UpcomingMovieDetailApiResponse> detailFuture = asyncService.fetchDetails(movieId, apiKey);
+
+    // 병령 완료 대기
+    CompletableFuture.allOf(creditsFuture,releaseFuture, detailFuture).join();
+
+    // 결과 꺼내기
+    UpcomingMovieCreditApiResponse credits = creditsFuture.get();
+    UpcomingMovieReleaseDateApiResponse releaseDate = releaseFuture.get();
+    UpcomingMovieDetailApiResponse details = detailFuture.get();
+
+    // DTO 채우기
+    dtoEnricher.enrichCredits(baseDto, credits);
+    dtoEnricher.enrichCertification(baseDto, releaseDate);
+    dtoEnricher.enrichCountry(baseDto, details);
+
+    return baseDto;
+  }
+
+  public List<UpcomingMovieDto> fetchUpcomingMovies() {
+    int page = 1;
+    UpcomingMovieUpcomingApiResponse response = upcomingMovieApi.getUpcomingMovies(apiKey, "en-US", page, "US");
+    int totalPages = response.getTotalPages();
+
+    List<UpcomingMovieDto> allMovies = new java.util.ArrayList<>(response.getMovies());
+    for (page = 2; page <= totalPages; page++) {
+        UpcomingMovieUpcomingApiResponse nextPage = upcomingMovieApi.getUpcomingMovies(apiKey, "en-US", page, "US");
+        allMovies.addAll(nextPage.getMovies());
+    }
+    return allMovies;
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/service/common/UpcomingMovieUnifiedSaveService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/service/common/UpcomingMovieUnifiedSaveService.java
@@ -1,0 +1,26 @@
+package com.grepp.smartwatcha.app.model.admin.upcoming.service.common;
+
+import com.grepp.smartwatcha.app.model.admin.upcoming.dto.UpcomingMovieDto;
+import com.grepp.smartwatcha.app.model.admin.upcoming.service.neo4j.UpcomingMovieSaveNeo4jService;
+import com.grepp.smartwatcha.app.model.admin.upcoming.service.jpa.UpcomingMovieSaveJpaService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UpcomingMovieUnifiedSaveService {
+
+  private final UpcomingMovieSaveJpaService jpaService;
+  private final UpcomingMovieSaveNeo4jService neo4jService;
+
+  public void saveAll(UpcomingMovieDto dto) {
+    try {
+      jpaService.saveToJpa(dto);
+      neo4jService.saveToNeo4j(dto);
+    } catch (Exception e) {
+      log.error("Neo4j 저장 실패 → JPA 롤백은 되지 않음. 수동 삭제 고려");
+    }
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/service/jpa/UpcomingMovieSyncTimeJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/service/jpa/UpcomingMovieSyncTimeJpaService.java
@@ -1,0 +1,28 @@
+package com.grepp.smartwatcha.app.model.admin.upcoming.service.jpa;
+
+import com.grepp.smartwatcha.app.model.admin.upcoming.repository.jpa.UpcomingMovieSyncTimeJpaRepository;
+import com.grepp.smartwatcha.infra.jpa.entity.SyncTimeEntity;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpcomingMovieSyncTimeJpaService {
+  private final UpcomingMovieSyncTimeJpaRepository upcomingMovieSyncTimeJpaRepository;
+
+  public void update(String type){
+    upcomingMovieSyncTimeJpaRepository.save(
+        SyncTimeEntity.builder()
+            .type(type)
+            .syncTime(LocalDateTime.now())
+            .build()
+    );
+  }
+
+  public LocalDateTime getLastSyncTime(String type){
+    return upcomingMovieSyncTimeJpaRepository.findById(type)
+        .map(SyncTimeEntity::getSyncTime)
+        .orElse(null);
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/service/neo4j/UpcomingMovieGenreFetchNeo4jService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/service/neo4j/UpcomingMovieGenreFetchNeo4jService.java
@@ -1,0 +1,38 @@
+package com.grepp.smartwatcha.app.model.admin.upcoming.service.neo4j;
+
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.api.UpcomingMovieGenreApi;
+import com.grepp.smartwatcha.app.model.admin.upcoming.dto.UpcomingMovieGenreDto;
+import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingMovieGenreApiResponse;
+import jakarta.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpcomingMovieGenreFetchNeo4jService {
+
+  private final UpcomingMovieGenreApi movieGenreApi;
+
+  @Value("${tmdb.api.key}")
+  private String apiKey;
+
+  private final Map<Integer, String> genreMap = new HashMap<>();
+
+  @PostConstruct
+  public void init() {
+    UpcomingMovieGenreApiResponse response = movieGenreApi.getGenres(apiKey, "en");
+
+    if (response != null || response.getGenres() != null) {
+      for(UpcomingMovieGenreDto genre : response.getGenres()) {
+        genreMap.put(genre.getId(), genre.getName());
+      }
+    }
+  }
+
+  public Map<Integer, String> getGenreMap() {
+    return genreMap;
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/service/neo4j/UpcomingMovieGenreMergeHelper.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/service/neo4j/UpcomingMovieGenreMergeHelper.java
@@ -1,0 +1,40 @@
+package com.grepp.smartwatcha.app.model.admin.upcoming.service.neo4j;
+
+import com.grepp.smartwatcha.infra.neo4j.node.GenreNode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UpcomingMovieGenreMergeHelper {
+
+  private final UpcomingMovieGenreFetchNeo4jService genreFetchService;
+
+  public List<GenreNode> mergeGenres(List<GenreNode> existing, List<Integer> incomingGenreIds) {
+    Map<Integer, String> genreMap = genreFetchService.getGenreMap();
+
+    Set<String> incomingNames = incomingGenreIds.stream()
+        .map(genreMap::get)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
+
+    Set<String> existingNames = existing.stream()
+        .map(GenreNode::getName)
+        .collect(Collectors.toSet());
+
+    incomingNames.removeAll(existingNames);
+
+    List<GenreNode> merged = new ArrayList<>(existing);
+    for (String name : incomingNames) {
+      merged.add(new GenreNode(name));
+    }
+
+    return merged;
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/service/neo4j/UpcomingMovieSaveNeo4jService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/upcoming/service/neo4j/UpcomingMovieSaveNeo4jService.java
@@ -1,0 +1,84 @@
+package com.grepp.smartwatcha.app.model.admin.upcoming.service.neo4j;
+
+import com.grepp.smartwatcha.app.model.admin.upcoming.dto.UpcomingMovieDto;
+import com.grepp.smartwatcha.app.model.admin.upcoming.mapper.UpcomingMovieMapper;
+import com.grepp.smartwatcha.app.model.admin.upcoming.repository.neo4j.UpcomingMovieNeo4jRepository;
+import com.grepp.smartwatcha.infra.neo4j.node.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(transactionManager = "neo4jTransactionManager")
+public class UpcomingMovieSaveNeo4jService {
+
+  private final UpcomingMovieNeo4jRepository movieRepository;
+  private final UpcomingMovieGenreMergeHelper genreMergeHelper;
+  private final UpcomingMovieMapper upcomingMovieMapper;
+
+  public void saveToNeo4j(UpcomingMovieDto dto) {
+    Optional<MovieNode> optional = movieRepository.findById(dto.getId());
+
+    if (optional.isPresent()) {
+      MovieNode existing = optional.get();
+
+      existing.setActors(mergeActors(existing.getActors(), dto.getActorNames()));
+      existing.setDirectors(mergeDirectors(existing.getDirectors(), dto.getDirectorNames()));
+      existing.setWriters(mergeWriters(existing.getWriters(), dto.getWriterNames()));
+      existing.setGenres(genreMergeHelper.mergeGenres(existing.getGenres(), dto.getGenreIds()));
+
+      //log.info("🔁 [Neo4j 병합 저장 시도] 영화 ID: {}, 제목: {}, 인증등급: {}, 타입: {}, 국가: {}", dto.getId(), dto.getTitle(), dto.getCertification(), dto.getReleaseType(), dto.getCountry());
+      movieRepository.save(existing);
+      //log.info("✅ [Neo4j 병합 저장 완료] 영화 ID: {}", dto.getId());
+    } else {
+      List<GenreNode> genreNodes = genreMergeHelper.mergeGenres(new ArrayList<>(), dto.getGenreIds());
+
+      MovieNode node = upcomingMovieMapper.toNeo4jNode(
+          dto,
+          dto.getActorNames().stream().map(ActorNode::new).toList(),
+          dto.getDirectorNames().stream().map(DirectorNode::new).toList(),
+          dto.getWriterNames().stream().map(WriterNode::new).toList(),
+          genreNodes
+      );
+
+      //log.info("🔁 [Neo4j 저장 시도] 영화 ID: {}, 제목: {}, 인증등급: {}, 타입: {}, 국가: {}", dto.getId(), dto.getTitle(), dto.getCertification(), dto.getReleaseType(), dto.getCountry());
+      movieRepository.save(node);
+      //log.info("✅ [Neo4j 저장 완료] 영화 ID: {}", dto.getId());
+    }
+  }
+
+  private List<ActorNode> mergeActors(List<ActorNode> existing, List<String> incoming) {
+    Set<String> names = existing.stream().map(ActorNode::getName).collect(Collectors.toSet());
+    for (String name : incoming) {
+      if (!names.contains(name)) {
+        existing.add(new ActorNode(name));
+      }
+    }
+    return existing;
+  }
+
+  private List<DirectorNode> mergeDirectors(List<DirectorNode> existing, List<String> incoming) {
+    Set<String> names = existing.stream().map(DirectorNode::getName).collect(Collectors.toSet());
+    for (String name : incoming) {
+      if (!names.contains(name)) {
+        existing.add(new DirectorNode(name));
+      }
+    }
+    return existing;
+  }
+
+  private List<WriterNode> mergeWriters(List<WriterNode> existing, List<String> incoming) {
+    Set<String> names = existing.stream().map(WriterNode::getName).collect(Collectors.toSet());
+    for (String name : incoming) {
+      if (!names.contains(name)) {
+        existing.add(new WriterNode(name));
+      }
+    }
+    return existing;
+  }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/infra/jpa/entity/MovieEntity.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/infra/jpa/entity/MovieEntity.java
@@ -37,7 +37,6 @@ public class MovieEntity extends BaseEntity {
     private String certification; // 관람등급
 
     @Lob
-    @Length(max=256)
     private String overview;
 
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/infra/jpa/entity/SyncTimeEntity.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/infra/jpa/entity/SyncTimeEntity.java
@@ -1,0 +1,25 @@
+package com.grepp.smartwatcha.infra.jpa.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Table(name = "syncTime")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class SyncTimeEntity {
+  @Id
+  private String type;
+
+  private LocalDateTime syncTime;
+}

--- a/backend/src/main/resources/templates/admin/movie/upcoming/movie.html
+++ b/backend/src/main/resources/templates/admin/movie/upcoming/movie.html
@@ -1,0 +1,200 @@
+<html lang="en" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layoutAdmin}" xmlns="http://www.w3.org/1999/html">
+<head>
+  <meta charset="UTF-8">
+  <title>Upcoming movies</title>
+  <style>
+    h4 {
+      margin-top: 0;
+    }
+
+    .dashboard-section {
+      flex: 1;
+      padding: 2rem;
+      min-width: 0;
+    }
+
+    .upcomingMovie-controls select,
+    .upcomingMovie-controls input[type="text"],
+    .upcomingMovie-controls button {
+      height: 42px;
+      padding: 0 0.8rem;
+      background-color: #1e1e1e;
+      color: white;
+      border: 1px solid #444;
+      border-radius: 4px;
+      font-size: 0.95rem;
+      box-sizing: border-box;
+      margin: 0;
+      line-height: 1;
+    }
+
+    .upcomingMovie-table thead tr {
+      border-bottom: 2px solid #444;
+      background-color: #2c2c2c;
+    }
+
+    .upcomingMovie-table th {
+      color: #e0e0e0;
+      font-weight: 600;
+      font-size: 0.9rem;
+      text-align: left;
+    }
+
+    .upcomingMovie-layout {
+      display: flex;
+      gap: 2rem;
+      width: 100%;
+      max-width: 100%;
+      overflow: hidden;
+    }
+
+    .upcomingMovie-table {
+      flex: 1 1 70%;
+      min-width: 0;
+    }
+
+    .upcomingMovie-detail-panel p {
+      margin: 0.5rem 0;
+    }
+
+    table.highlight tbody tr td {
+      color: white;
+    }
+
+    tr:hover {
+      background-color: #2a2a2a;
+      cursor: pointer;
+    }
+
+    .pagination-container {
+      display: flex;
+      justify-content: center;
+      margin-top: 2.5rem;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .page-button {
+      color: white;
+      background-color: #2a2a2a;
+      border: 1px solid #444;
+      padding: 0.4rem 0.8rem;
+      text-decoration: none;
+      border-radius: 4px;
+      font-size: 0.9rem;
+      transition: background-color 0.3s ease;
+    }
+
+    .page-button:hover {
+      background-color: #3d3d3d;
+    }
+
+    .page-button.active {
+      background-color: #ff6262;
+      font-weight: bold;
+      border-color: #ff6262;
+    }
+
+  </style>
+</head>
+<body>
+<section class="dashboard-section" layout:fragment="main-content">
+  <!--메인 콘텐츠 영역-->
+  <h4 style="color: lightgrey">🗓️ Upcoming movies</h4>
+
+  <div style="display: flex; justify-content: flex-end; align-items: center; margin-bottom: 10px;">
+    <div style="color: steelblue ; display: flex; align-items: center; gap: 12px;">
+
+      <div style="font-size: 1rem;">
+        <strong>Last Sync Time:</strong>
+        <span th:text="${lastSyncTime != null ? #temporals.format(lastSyncTime, 'yyyy-MM-dd HH:mm') : 'N/A'}">N/A</span>
+      </div>
+
+      <button type="button" class="waves-effect" onclick="syncUpcomingMovies()" style="background-color: #ff6262; color: white; border: none; padding: 6px 12px; border-radius: 4px;
+        font-size: 0.95rem; line-height: 1.2; display: flex; align-items: center; gap: 6px;"><i class="material-icons" style="font-size: 1.1rem;">cached</i>Manual Sync
+      </button>
+
+    </div>
+  </div>
+
+  <div class="upcomingMovie-layout">
+    <!-- Upcoming Movie 테이블 -->
+    <div class="upcomingMovie-table">
+      <table class="highlight">
+        <thead>
+        <tr>
+          <th>ID</th>
+          <th>Title</th>
+          <th>Poster</th>
+          <th>Overview</th>
+          <th>Release Date</th>
+          <th>Country</th>
+          <th>Certification</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="movie : ${movies}">
+          <td th:text="${movie.id}" style="width: 7%">ID</td>
+          <td th:text="${movie.title}"style="width: 15%">Title</td>
+          <td>
+            <img th:src="'https://image.tmdb.org/t/p/w500' + ${movie.poster}" alt="Poster" style=" width: 80px;">
+          </td>
+          <td th:text="${movie.overview}" style="width: 50%;">Overview</td>
+          <td th:text="${#temporals.format(movie.releaseDate, 'yyyy-MM-dd')}" style="width: 12%">Release Date</td>
+          <td th:text="${movie.country}" style="width: 8%">Country</td>
+          <td th:text="${movie.certification}" style="width: 20%">Certification</td>
+        </tr>
+
+        <tr th:if="${#lists.isEmpty(pageResponse.content)}">
+          <td colspan="7">No Movies found.</td>
+        </tr>
+        </tbody>
+      </table>
+
+      <!-- Pagination -->
+      <div class="pagination-container">
+        <!-- Prev -->
+        <a th:if="${pageResponse.startNumber() > 1}"
+           th:href="@{${pageResponse.url()}(page=${pageResponse.startNumber() - 2})}"
+           class="page-button">Prev</a>
+
+        <!-- now -->
+        <a th:each="i : ${#numbers.sequence(pageResponse.startNumber(), pageResponse.endNumber())}"
+           th:href="@{${pageResponse.url()}(page=${i - 1})}"
+           th:text="${i}"
+           th:classappend="${i == pageResponse.currentNumber()} ? 'page-button active' : 'page-button'">
+        </a>
+
+        <!-- Next -->
+        <a th:if="${pageResponse.endNumber() < pageResponse.totalPages()}"
+           th:href="@{${pageResponse.url()}(page=${pageResponse.endNumber()})}"
+           class="page-button">Next</a>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    function syncUpcomingMovies() {
+      fetch('/admin/movies/upcoming/sync-manual-test', {
+        method: 'GET'
+      })
+      .then(res => {
+        console.log("응답 상태:", res.status);
+        if (res.ok) {
+          alert("✅ Sync completed successfully!");
+          window.location.href = '/admin/movies/upcoming?v=' + new Date().getTime();
+        } else {
+          alert("❌ Sync failed! (" + res.status + ")");
+        }
+      })
+      .catch(err => {
+        console.error(err);
+        alert("⚠️ An error occurred!");
+      });
+    }
+  </script>
+
+</section>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/tag/list.html
+++ b/backend/src/main/resources/templates/admin/tag/list.html
@@ -95,6 +95,12 @@
       background-color: #3d3d3d;
     }
 
+    .page-button.active {
+      background-color: #ff6262;
+      font-weight: bold;
+      border-color: #ff6262;
+    }
+
     @media (max-width: 900px) {
       .tag-layout {
         flex-direction: column;

--- a/backend/src/main/resources/templates/layoutAdmin.html
+++ b/backend/src/main/resources/templates/layoutAdmin.html
@@ -128,7 +128,7 @@
                             <li><a href="/admin/movies" style="color:white;">All Movies</a></li>
                             <li><a href="/admin/movies/manual" style="color:white;">Manual Movie Registration</a></li>
                             <li><a href="/admin/movies/edit" style="color:white;">Edit Movie Info</a></li>
-                            <li><a href="/admin/coming-soon" style="color:white;">Upcoming Releases</a></li>
+                            <li><a href="/admin/movies/upcoming" style="color:white;">Upcoming Movies</a></li>
                         </ul>
                     </div>
                 </li>


### PR DESCRIPTION
## 📌 과제 설명
TMDB API를 활용한 영화 공개 예정작 수동 동기화 기능을 구현하였습니다.  
공개 예정 영화 목록을 TMDB에서 가져온 후, 상세 정보를 병렬로 조회하여 MySQL(JPA)과 Neo4j에 저장하는 전체 흐름을 개발하였습니다.


## 👩‍💻 요구 사항과 구현 내용

### ✅ fix: 영화 관리 사이드메뉴 upcoming 경로 수정
- 사이드 메뉴 경로를 `/admin/coming-soon` → `/admin/movies/upcoming` 으로 정정.

### ✅ style: 페이지네이션 버튼 색상 개선
- 페이지네이션 버튼이 hover/focus 시 안 보이던 이슈 해결.

### ✅ refactor: MovieEntity @Length 제한 제거
- 영화 제목이 잘리는 문제 방지를 위해 `@Length(max=256)` 어노테이션 제거.

### ✅ feat: TMDB API 연동을 위한 클라이언트 및 응답 DTO 정의
- 다음 API에 대한 클라이언트 및 응답 DTO 구현:
  - `/movie/upcoming`
  - `/movie/{id}`
  - `/movie/{id}/release_dates`
  - `/movie/{id}/credits`

### ✅ feat: TMDB API 병렬 호출 및 영화 상세 정보 Enricher 구현
- `CompletableFuture`를 사용하여 병렬로 API 호출.
- 응답값을 하나의 영화 DTO로 통합하는 Enricher 로직 구현.

### ✅ feat: TMDB 연동 영화 데이터를 JPA & Neo4j 저장하는 기능 구현
- JPA에 `MovieEntity`, Neo4j에 `MovieNode`, `ActorNode`, `DirectorNode` 등 관계 저장.

### ✅ feat: 영화 예정작 수동 동기화 API 및 일괄 저장 흐름 구현
- `/admin/movies/upcoming/sync-manual-test` API 추가.
- 동기화 실행 시 TMDB에서 72건 불러와 enrich 후 저장.

- 🕒  **총 소요 시간**: 약 `35초`
- 총 동기화 대상 영화: `72건`(51건 저장, 21건 제외)
- 동기화 수행 시간:  
  - **시작**: `2025-05-16T11:55:52.768+09:00`  
  - **종료**: `2025-05-16T11:56:27.309+09:00`  

### ✅ feat: TMDB 영화 상세 정보 조회용 API 클라이언트 추가
- `/movie/{id}` 호출을 위한 클라이언트 구성.
- 인증, 언어 파라미터 등 설정 포함.

### ✅ feat: TMDB 공개 예정작 상세 비동기 조회 서비스 추가
- 다건 조회 시 비동기 enrich 처리 (`UpcomingMovieAsyncFetchService`)


## ✅ PR 포인트 & 궁금한 점
- JPA와 Neo4j 양쪽에 저장하는 병합 흐름의 구조가 적절한지 검토 부탁드립니다.
- 병렬 처리 구조(`CompletableFuture`)의 예외 처리나 개선점이 있을지 확인해주시면 감사하겠습니다.
- 디렉토리와 파일명이 잘 되어있는지 확인해주시면 감사하겠습니다.
