### PR TITLE
refactor: 마이페이지 정보수정/활동관리 DTO 적용 및 Entity 직접 노출 제거

### DIFF
--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/user/MyPageController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/user/MyPageController.java
@@ -24,7 +24,8 @@ public class MyPageController {
             return "redirect:/admin";
         }
         UserEntity user = userJpaService.findById(userDetails.getUser().getId());
-        model.addAttribute("user", user);
+        com.grepp.smartwatcha.app.model.user.dto.UserInfoDto userDto = com.grepp.smartwatcha.app.model.user.dto.UserInfoDto.from(user);
+        model.addAttribute("user", userDto);
         return "user/mypage-info";
     }
 
@@ -65,8 +66,16 @@ public class MyPageController {
             return "redirect:/admin";
         }
         Long userId = userDetails.getUser().getId();
-        model.addAttribute("ratedMovies", userJpaService.findRatedMoviesByUserId(userId));
-        model.addAttribute("wishlistMovies", userJpaService.findWishlistMoviesByUserId(userId));
+        var ratedEntities = userJpaService.findRatedMoviesByUserId(userId);
+        var wishlistEntities = userJpaService.findWishlistMoviesByUserId(userId);
+        var ratedMovies = ratedEntities.stream()
+                .map(com.grepp.smartwatcha.app.model.user.dto.RatedMovieDto::from)
+                .toList();
+        var wishlistMovies = wishlistEntities.stream()
+                .map(com.grepp.smartwatcha.app.model.user.dto.WishlistMovieDto::from)
+                .toList();
+        model.addAttribute("ratedMovies", ratedMovies);
+        model.addAttribute("wishlistMovies", wishlistMovies);
         return "user/mypage-activity";
     }
 } 

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/user/dto/RatedMovieDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/user/dto/RatedMovieDto.java
@@ -1,0 +1,24 @@
+package com.grepp.smartwatcha.app.model.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RatedMovieDto {
+    private Long movieId;
+    private String title;
+    private String poster;
+    private Double score;
+
+    public static RatedMovieDto from(com.grepp.smartwatcha.infra.jpa.entity.RatingEntity entity) {
+        return new RatedMovieDto(
+            entity.getMovie().getId(),
+            entity.getMovie().getTitle(),
+            entity.getMovie().getPoster(),
+            entity.getScore()
+        );
+    }
+} 

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/user/dto/UserInfoDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/user/dto/UserInfoDto.java
@@ -1,0 +1,22 @@
+package com.grepp.smartwatcha.app.model.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfoDto {
+    private String email;
+    private String name;
+    private String phoneNumber;
+    // 필요시 생성자, builder 등 추가
+    public static UserInfoDto from(com.grepp.smartwatcha.infra.jpa.entity.UserEntity entity) {
+        return new UserInfoDto(
+            entity.getEmail(),
+            entity.getName(),
+            entity.getPhoneNumber()
+        );
+    }
+} 

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/user/dto/WishlistMovieDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/user/dto/WishlistMovieDto.java
@@ -1,0 +1,22 @@
+package com.grepp.smartwatcha.app.model.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WishlistMovieDto {
+    private Long movieId;
+    private String title;
+    private String poster;
+
+    public static WishlistMovieDto from(com.grepp.smartwatcha.infra.jpa.entity.InterestEntity entity) {
+        return new WishlistMovieDto(
+            entity.getMovie().getId(),
+            entity.getMovie().getTitle(),
+            entity.getMovie().getPoster()
+        );
+    }
+} 


### PR DESCRIPTION
📌 과제 설명
마이페이지(정보수정/활동관리)에서 Entity를 직접 View에 노출하지 않고, DTO로 변환하여 전달하도록 리팩토링했습니다.

👩‍💻 요구 사항과 구현 내용
refactor: Entity → DTO 변환 적용
  - UserEntity → UserInfoDto
  - RatingEntity → RatedMovieDto

InterestEntity → WishlistMovieDto

user.dto 패키지에 DTO 클래스 신규 생성 및 from 메서드 구현

MyPageController에서 model에 addAttribute 시 DTO 변환 적용

템플릿에서 DTO 필드만 사용하도록 구조 개선

✅ PR 포인트
mypage 접근 시 발생하던 500 에러 해결 여부
Entity가 직접 노출되지 않고 DTO로 안전하게 변환되는지
View에서 필요한 데이터만 전달되고, 불필요한 정보가 노출되지 않는지
컨트롤러, 서비스, 템플릿 간 데이터 전달 구조의 일관성
