### PR TITLE
feat(admin): 공개 예정작 동기화 오류 수정 및 안정화

### DIFF
--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/admin/AdminController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/admin/AdminController.java
@@ -40,9 +40,10 @@ public class AdminController {
 
     // Sync 정보
     SyncTimeEntity upcomingSyncTime = upcomingMovieSyncTimeJpaRepository.findById("upcoming").orElse(null);
-    model.addAttribute("lastSyncTime", syncTime != null ? upcomingSyncTime.getSyncTime() : null);
-    model.addAttribute("newlyAddedCount", syncTime != null ? upcomingSyncTime.getNewlyAddedCount() : 0);
-    model.addAttribute("failedCount", syncTime != null ? upcomingSyncTime.getFailedCount() : 0);
+    model.addAttribute("lastSyncTime", upcomingSyncTime != null ? upcomingSyncTime.getSyncTime() : null);
+    model.addAttribute("newlyAddedCount", upcomingSyncTime != null ? upcomingSyncTime.getNewlyAddedCount() : 0);
+    model.addAttribute("failedCount", upcomingSyncTime != null ? upcomingSyncTime.getFailedCount() : 0);
+    model.addAttribute("enrichFailedCount", syncTime != null ? upcomingSyncTime.getEnrichFailedCount() : 0);
 
     // 최근 등록된 공개 예정작 (5개)
     List<MovieEntity> recentUpcoming = adminDashboardJpaService

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/admin/AdminUserController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/admin/AdminUserController.java
@@ -3,9 +3,11 @@ package com.grepp.smartwatcha.app.controller.web.admin;
 import com.grepp.smartwatcha.app.model.admin.user.dto.AdminRatingDto;
 import com.grepp.smartwatcha.app.model.admin.user.service.AdminUserJpaService;
 import com.grepp.smartwatcha.app.model.admin.user.dto.AdminUserListResponseDto;
-import com.grepp.smartwatcha.app.model.admin.user.repository.AdminUserRatingJpaRepository;
 import com.grepp.smartwatcha.app.model.admin.user.service.AdminUserRatingJpaService;
+import com.grepp.smartwatcha.infra.error.exceptions.CommonException;
+import com.grepp.smartwatcha.infra.jpa.enums.Role;
 import com.grepp.smartwatcha.infra.response.PageResponse;
+import com.grepp.smartwatcha.infra.response.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -33,7 +35,7 @@ public class AdminUserController {
       @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "6") int size,
       @RequestParam(required = false) Long id,
       @RequestParam(required = false) String keyword,
-      @RequestParam(required = false) String role,
+      @RequestParam(required = false) Role role,
       @RequestParam(required = false) Boolean activated,
       Model model) {
 
@@ -41,8 +43,12 @@ public class AdminUserController {
     Page<AdminUserListResponseDto> users = adminUserJpaService.findUserByFilter(keyword, role, activated, pageable);
 
     AdminUserListResponseDto selectedUser = null;
+
     if (id != null) {
       selectedUser = adminUserJpaService.findUserById(id);
+      if(selectedUser == null) {
+        throw new CommonException(ResponseCode.BAD_REQUEST);  // 존재하지 않는 유저 ID
+      }
     }
 
     PageResponse<AdminUserListResponseDto> pageResponse = new PageResponse<>("/admin/users", users, 5);
@@ -84,9 +90,16 @@ public class AdminUserController {
 
     if(id != null) {
       selectedUser = adminUserJpaService.findUserById(id);
+      if(selectedUser == null) {
+        throw new CommonException(ResponseCode.BAD_REQUEST); // 존재하지 않는 유저 ID
+      }
       userId = id;
+
     } else if (keyword != null && !keyword.isEmpty()) {
       selectedUser = adminUserJpaService.findUserByName(keyword);
+      if(selectedUser == null) {
+        throw new CommonException(ResponseCode.BAD_REQUEST); // 검색된 유저 없음
+      }
       userId = selectedUser.getId();
     }
 

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/AdminDashboardJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/AdminDashboardJpaService.java
@@ -2,7 +2,7 @@ package com.grepp.smartwatcha.app.model.admin;
 
 import com.grepp.smartwatcha.app.model.admin.movie.list.AdminMovieJpaRepository;
 import com.grepp.smartwatcha.app.model.admin.movie.upcoming.repository.jpa.UpcomingMovieSyncTimeJpaRepository;
-import com.grepp.smartwatcha.app.model.admin.tag.AdminTagJpaRespository;
+import com.grepp.smartwatcha.app.model.admin.tag.AdminTagJpaRepository;
 import com.grepp.smartwatcha.app.model.admin.user.repository.AdminUserJpaRepository;
 import com.grepp.smartwatcha.infra.jpa.entity.MovieEntity;
 import com.grepp.smartwatcha.infra.jpa.entity.SyncTimeEntity;
@@ -17,7 +17,7 @@ public class AdminDashboardJpaService {
 
   private final AdminUserJpaRepository adminUserJpaRepository;
   private final AdminMovieJpaRepository adminMovieJpaRepository;
-  private final AdminTagJpaRespository adminTagJpaRespository;
+  private final AdminTagJpaRepository adminTagJpaRepository;
   private final UpcomingMovieSyncTimeJpaRepository upcomingMovieSyncTimeJpaRepository;
 
   public long getTotalUsers() {
@@ -46,7 +46,7 @@ public class AdminDashboardJpaService {
   }
 
   public long getTotalTags() {
-    return adminTagJpaRespository.count();
+    return adminTagJpaRepository.count();
   }
 
   public int getNewlyAddedMovieCount() {

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/AdminDashboardJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/AdminDashboardJpaService.java
@@ -20,7 +20,7 @@ public class AdminDashboardJpaService {
   private final AdminTagJpaRespository adminTagJpaRespository;
   private final UpcomingMovieSyncTimeJpaRepository upcomingMovieSyncTimeJpaRepository;
 
-  public long getTotalUsers(){
+  public long getTotalUsers() {
     return adminUserJpaRepository.count();
   }
 
@@ -32,7 +32,7 @@ public class AdminDashboardJpaService {
     return adminUserJpaRepository.countByActivatedFalse();
   }
 
-  public long getTotalMovies(){
+  public long getTotalMovies() {
     return adminMovieJpaRepository.count();
   }
 
@@ -49,13 +49,13 @@ public class AdminDashboardJpaService {
     return adminTagJpaRespository.count();
   }
 
-  public Object getNewlyAddedMovieCount() {
+  public int getNewlyAddedMovieCount() {
     return upcomingMovieSyncTimeJpaRepository.findTopByTypeOrderBySyncTimeDesc("upcoming")
         .map(SyncTimeEntity::getNewlyAddedCount)
         .orElse(0);
   }
 
-  public Object getFailedSyncCount() {
+  public int getFailedSyncCount() {
     return upcomingMovieSyncTimeJpaRepository.findTopByTypeOrderBySyncTimeDesc("upcoming")
         .map(SyncTimeEntity::getFailedCount)
         .orElse(0);

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/list/mapper/AdminMovieMapper.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/list/mapper/AdminMovieMapper.java
@@ -6,20 +6,24 @@ import java.time.LocalDateTime;
 
 public class AdminMovieMapper {
   public static AdminMovieListResponseDto toDto(MovieEntity movie) {
-   AdminMovieListResponseDto dto = AdminMovieListResponseDto.builder()
-       .id(movie.getId())
-       .title(movie.getTitle())
-       .releaseDate(movie.getReleaseDate())
-       .country(movie.getCountry())
-       .poster(movie.getPoster())
-       .isReleased(movie.getIsReleased())
-       .certification(movie.getCertification())
-       .overview(movie.getOverview())
-       .build();
+    LocalDateTime now = LocalDateTime.now();
 
-   boolean isRecentlyModified = movie.getModifiedAt() != null && movie.getModifiedAt().isAfter(LocalDateTime.now().minusDays(3));
-   dto.setUpdatedRecently(isRecentlyModified);
+    AdminMovieListResponseDto dto = AdminMovieListResponseDto.builder()
+        .id(movie.getId())
+        .title(movie.getTitle())
+        .releaseDate(movie.getReleaseDate())
+        .country(movie.getCountry())
+        .poster(movie.getPoster())
+        .isReleased(movie.getIsReleased())
+        .certification(movie.getCertification())
+        .overview(movie.getOverview())
+        .build();
 
-   return dto;
+    boolean isRecentlyModified = movie.getModifiedAt() != null &&
+        movie.getModifiedAt().isAfter(now.minusDays(3));
+
+    dto.setUpdatedRecently(isRecentlyModified);
+
+    return dto;
   }
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/dto/UpcomingMovieDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/dto/UpcomingMovieDto.java
@@ -5,9 +5,13 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Builder;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Data
+@Builder
 public class UpcomingMovieDto {
   private Long id;
   private String title;
@@ -24,7 +28,7 @@ public class UpcomingMovieDto {
   private String originalLanguage;
 
   @JsonProperty("genre_ids")
-  private List<Integer> genreIds;
+  private List<Long> genreIds;
 
   @JsonProperty("release_type")
   private Integer releaseType;
@@ -39,6 +43,16 @@ public class UpcomingMovieDto {
   private List<String> writerNames = new ArrayList<>();
 
   public LocalDateTime getReleaseDateTime() {
-    return LocalDate.parse(releaseDate).atStartOfDay(); // 00:00
+    if (releaseDate == null || releaseDate.isBlank()){
+      log.warn("📅 releaseDate가 비어 있어 LocalDateTime으로 변환할 수 없습니다. [title: {}]", title);
+      return null;
+    }
+
+    try {
+      return LocalDate.parse(releaseDate).atStartOfDay(); // 00:00
+    } catch (Exception e) {
+      log.warn("📅 releaseDate 파싱 실패: '{}' [title: {}]", releaseDate, title);
+      return null;
+    }
   }
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/dto/UpcomingMovieGenreDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/dto/UpcomingMovieGenreDto.java
@@ -4,6 +4,6 @@ import lombok.Data;
 
 @Data
 public class UpcomingMovieGenreDto {
-  private Integer id;
+  private Long id;
   private String name;
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/mapper/UpcomingMovieMapper.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/mapper/UpcomingMovieMapper.java
@@ -10,6 +10,7 @@ import com.grepp.smartwatcha.infra.neo4j.node.MovieNode;
 import com.grepp.smartwatcha.infra.neo4j.node.WriterNode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -51,11 +52,10 @@ public class UpcomingMovieMapper {
     List<GenreNode> genres
   ){
     MovieNode movie = new MovieNode(dto.getId(), dto.getTitle());
-    movie.setActors(actors);
-    movie.setDirectors(directors);
-    movie.setWriters(writers);
-    movie.setGenres(genres);
-
+    movie.setActors(new ArrayList<>(actors));
+    movie.setDirectors(new ArrayList<>(directors));
+    movie.setWriters(new ArrayList<>(writers));
+    movie.setGenres(new ArrayList<>(genres));
     return movie;
   }
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/repository/neo4j/UpcomingActorNeo4jRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/repository/neo4j/UpcomingActorNeo4jRepository.java
@@ -1,0 +1,8 @@
+package com.grepp.smartwatcha.app.model.admin.movie.upcoming.repository.neo4j;
+
+import com.grepp.smartwatcha.infra.neo4j.node.ActorNode;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+public interface UpcomingActorNeo4jRepository extends Neo4jRepository<ActorNode, String> {
+
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/repository/neo4j/UpcomingDirectorNeo4jRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/repository/neo4j/UpcomingDirectorNeo4jRepository.java
@@ -1,0 +1,8 @@
+package com.grepp.smartwatcha.app.model.admin.movie.upcoming.repository.neo4j;
+
+import com.grepp.smartwatcha.infra.neo4j.node.DirectorNode;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+public interface UpcomingDirectorNeo4jRepository extends Neo4jRepository<DirectorNode, String> {
+
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/repository/neo4j/UpcomingGenreNeo4jRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/repository/neo4j/UpcomingGenreNeo4jRepository.java
@@ -1,0 +1,8 @@
+package com.grepp.smartwatcha.app.model.admin.movie.upcoming.repository.neo4j;
+
+import com.grepp.smartwatcha.infra.neo4j.node.GenreNode;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+public interface UpcomingGenreNeo4jRepository extends Neo4jRepository<GenreNode, String> {
+
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/repository/neo4j/UpcomingMovieNeo4jRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/repository/neo4j/UpcomingMovieNeo4jRepository.java
@@ -1,9 +1,8 @@
 package com.grepp.smartwatcha.app.model.admin.movie.upcoming.repository.neo4j;
 
 import com.grepp.smartwatcha.infra.neo4j.node.MovieNode;
-import java.util.Optional;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 
 public interface UpcomingMovieNeo4jRepository extends Neo4jRepository<MovieNode, Long> {
-  Optional<MovieNode> findById(Integer tmdbId);
+
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/repository/neo4j/UpcomingWriterNeo4jRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/repository/neo4j/UpcomingWriterNeo4jRepository.java
@@ -1,0 +1,8 @@
+package com.grepp.smartwatcha.app.model.admin.movie.upcoming.repository.neo4j;
+
+import com.grepp.smartwatcha.infra.neo4j.node.WriterNode;
+import org.springframework.data.neo4j.repository.Neo4jRepository;
+
+public interface UpcomingWriterNeo4jRepository extends Neo4jRepository<WriterNode, String> {
+
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/service/common/UpcomingMovieAsyncFetchService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/service/common/UpcomingMovieAsyncFetchService.java
@@ -8,31 +8,54 @@ import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingM
 import com.grepp.smartwatcha.app.controller.api.admin.upcoming.payload.UpcomingMovieReleaseDateApiResponse;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UpcomingMovieAsyncFetchService {
 
-  //비동기 병렬 호출 서비스(실제 병렬 호출을 수행하는 비동기 서비스)
+  //비동기 병렬 호출 서비스
   private final UpcomingMovieCreditApi creditApi;
   private final UpcomingMovieReleaseDateApi releaseDateApi;
   private final UpcomingMovieDetailApi detailApi;
 
   @Async
   public CompletableFuture<UpcomingMovieCreditApiResponse> fetchCredits(Long movieId, String apiKey) {
-    return CompletableFuture.completedFuture(creditApi.getCredits(movieId, apiKey));
+    return CompletableFuture.supplyAsync(() -> {
+      try {
+        return creditApi.getCredits(movieId, apiKey);
+      } catch (Exception e) {
+        log.error("❌ [fetchCredits] 실패 - movieId: {}", movieId, e);
+        return null;
+      }
+    });
   }
 
   @Async
   public CompletableFuture<UpcomingMovieReleaseDateApiResponse> fetchReleaseDates(Long movieId,
       String apiKey) {
-    return CompletableFuture.completedFuture(releaseDateApi.getReleaseDates(movieId, apiKey));
+    return CompletableFuture.supplyAsync(() -> {
+      try {
+        return releaseDateApi.getReleaseDates(movieId, apiKey);
+      } catch (Exception e) {
+        log.error("❌ [fetchReleaseDates] 실패 - movieId: {}", movieId, e);
+        return null;
+      }
+    });
   }
 
   @Async
   public CompletableFuture<UpcomingMovieDetailApiResponse> fetchDetails(Long movieId, String apiKey) {
-    return CompletableFuture.completedFuture(detailApi.getDetails(movieId, apiKey));
+    return CompletableFuture.supplyAsync(() -> {
+      try {
+        return detailApi.getDetails(movieId, apiKey);
+      } catch (Exception e) {
+        log.error("❌ [fetchDetails] 실패 - movieId: {}", movieId, e);
+        return null;
+      }
+    });
   }
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/service/common/UpcomingMovieDetailEnricher.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/service/common/UpcomingMovieDetailEnricher.java
@@ -16,64 +16,77 @@ import org.springframework.stereotype.Component;
 public class UpcomingMovieDetailEnricher {
 
   public void enrichCredits(UpcomingMovieDto dto, UpcomingMovieCreditApiResponse credits) {
-    List<String> actorNames = credits.getCast().stream()
-        .sorted(Comparator.comparingInt(UpcomingMovieCastDto::getOrder))
-        .limit(5)
-        .map(UpcomingMovieCastDto::getName)
-        .toList();
-    dto.setActorNames(actorNames);
+    try {
+      if (credits == null) {
+        log.warn("⚠️ [enrichCredits] 응답이 null입니다. 영화 ID: {}", dto.getId());
+        return;
+      }
 
-    List<String> directorNames = credits.getCrew().stream()
-        .filter(crew -> "Director".equalsIgnoreCase(crew.getJob()))
-        .map(UpcomingMovieCrewDto::getName)
-        .distinct()
-        .toList();
-    dto.setDirectorNames(directorNames);
+      List<String> actorNames = credits.getCast().stream()
+          .sorted(Comparator.comparingInt(UpcomingMovieCastDto::getOrder))
+          .limit(5)
+          .map(UpcomingMovieCastDto::getName)
+          .toList();
+      dto.setActorNames(actorNames);
 
-    List<String> writerNames = credits.getCrew().stream()
-        .filter(crew -> "Writer".equalsIgnoreCase(crew.getJob()) || "Screenplay".equalsIgnoreCase(
-            crew.getJob()))
-        .map(UpcomingMovieCrewDto::getName)
-        .distinct()
-        .toList();
-    dto.setWriterNames(writerNames);
-  }
+      List<String> directorNames = credits.getCrew().stream()
+          .filter(crew -> "Director".equalsIgnoreCase(crew.getJob()))
+          .map(UpcomingMovieCrewDto::getName)
+          .distinct()
+          .toList();
+      dto.setDirectorNames(directorNames);
 
-  public void enrichCertification(UpcomingMovieDto dto,
-      UpcomingMovieReleaseDateApiResponse releaseData) {
-    if (releaseData == null || releaseData.getResults() == null) {
-      System.out.println("releaseData 또는 results 없음");
-      return;
+      List<String> writerNames = credits.getCrew().stream()
+          .filter(crew -> "Writer".equalsIgnoreCase(crew.getJob()) ||
+              "Screenplay".equalsIgnoreCase(crew.getJob()))
+          .map(UpcomingMovieCrewDto::getName)
+          .distinct()
+          .toList();
+      dto.setWriterNames(writerNames);
+
+    } catch (Exception e) {
+      log.warn("⚠️ [enrichCredits] 실패 - 영화 ID: {}, 제목: {}, 사유: {}", dto.getId(), dto.getTitle(), e.getMessage());
     }
-
-    // releaseType 먼저 설정
-    releaseData.getResults().stream()
-        .filter(r -> "US".equals(r.getIso_3166_1()))
-        .flatMap(r -> r.getRelease_dates().stream())
-        .filter(rd -> rd.getType() != null)
-        .sorted(Comparator.comparing(
-            UpcomingMovieReleaseDateApiResponse.ReleaseDateDetail::getReleaseDate))
-        .findFirst()
-        .ifPresent(rd -> dto.setReleaseType(rd.getType()));
-
-    // certification 설정
-    releaseData.getResults().stream()
-        .filter(r -> "US".equals(r.getIso_3166_1()))
-        .flatMap(r -> r.getRelease_dates().stream())
-        .filter(rd -> rd.getCertification() != null && !rd.getCertification().isBlank())
-        .sorted(Comparator.comparing(
-            UpcomingMovieReleaseDateApiResponse.ReleaseDateDetail::getReleaseDate))
-        .findFirst()
-        .ifPresent(rd -> {
-          dto.setCertification(rd.getCertification());
-        });
   }
 
-    public void enrichCountry (UpcomingMovieDto dto, UpcomingMovieDetailApiResponse detail){
-      if (detail.getProductionCountries() != null && !detail.getProductionCountries().isEmpty()) {
+  public void enrichCertification(UpcomingMovieDto dto, UpcomingMovieReleaseDateApiResponse releaseData) {
+    try {
+      if (releaseData == null || releaseData.getResults() == null) {
+        log.warn("⚠️ [enrichCertification] releaseData 또는 results 없음 - 영화 ID: {}", dto.getId());
+        return;
+      }
+
+      releaseData.getResults().stream()
+          .filter(r -> "US".equals(r.getIso_3166_1()))
+          .flatMap(r -> r.getRelease_dates().stream())
+          .filter(rd -> rd.getType() != null)
+          .sorted(Comparator.comparing(UpcomingMovieReleaseDateApiResponse.ReleaseDateDetail::getReleaseDate))
+          .findFirst()
+          .ifPresent(rd -> dto.setReleaseType(rd.getType()));
+
+      releaseData.getResults().stream()
+          .filter(r -> "US".equals(r.getIso_3166_1()))
+          .flatMap(r -> r.getRelease_dates().stream())
+          .filter(rd -> rd.getCertification() != null && !rd.getCertification().isBlank())
+          .sorted(Comparator.comparing(UpcomingMovieReleaseDateApiResponse.ReleaseDateDetail::getReleaseDate))
+          .findFirst()
+          .ifPresent(rd -> dto.setCertification(rd.getCertification()));
+
+    } catch (Exception e) {
+      log.warn("⚠️ [enrichCertification] 실패 - 영화 ID: {}, 제목: {}, 사유: {}", dto.getId(), dto.getTitle(), e.getMessage());
+    }
+  }
+
+  public void enrichCountry(UpcomingMovieDto dto, UpcomingMovieDetailApiResponse detail) {
+    try {
+      if (detail != null && detail.getProductionCountries() != null && !detail.getProductionCountries().isEmpty()) {
         String countryCode = detail.getProductionCountries().get(0).getIso31661();
         dto.setCountry(countryCode);
-
+      } else {
+        log.warn("⚠️ [enrichCountry] country 정보 없음 - 영화 ID: {}", dto.getId());
       }
+    } catch (Exception e) {
+      log.warn("⚠️ [enrichCountry] 실패 - 영화 ID: {}, 제목: {}, 사유: {}", dto.getId(), dto.getTitle(), e.getMessage());
+    }
   }
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/service/common/UpcomingMovieUnifiedSaveService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/service/common/UpcomingMovieUnifiedSaveService.java
@@ -1,8 +1,8 @@
 package com.grepp.smartwatcha.app.model.admin.movie.upcoming.service.common;
 
 import com.grepp.smartwatcha.app.model.admin.movie.upcoming.dto.UpcomingMovieDto;
-import com.grepp.smartwatcha.app.model.admin.movie.upcoming.service.neo4j.UpcomingMovieSaveNeo4jService;
 import com.grepp.smartwatcha.app.model.admin.movie.upcoming.service.jpa.UpcomingMovieSaveJpaService;
+import com.grepp.smartwatcha.app.model.admin.movie.upcoming.service.neo4j.UpcomingMovieSaveNeo4jService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,10 +17,28 @@ public class UpcomingMovieUnifiedSaveService {
 
   public void saveAll(UpcomingMovieDto dto) {
     try {
-      jpaService.saveToJpa(dto);
-      neo4jService.saveToNeo4j(dto);
+      jpaService.saveToJpa(dto); // MySQL 저장
     } catch (Exception e) {
-      log.error("Neo4j 저장 실패 → JPA 롤백은 되지 않음. 수동 삭제 고려");
+      log.error("❌ [JPA 저장 실패] 영화 ID: {}, 제목: {}", dto.getId(), dto.getTitle(), e);
+      throw new RuntimeException("JPA 저장 실패", e);
+    }
+
+    try {
+      neo4jService.saveToNeo4j(dto); // Neo4j 저장
+    } catch (Exception e) {
+      log.error("❌ [Neo4j 저장 실패] 영화 ID: {}, 제목: {}", dto.getId(), dto.getTitle());
+      log.error("❗ 예외 클래스: {}, 메시지: {}", e.getClass().getName(), e.getMessage());
+      log.error("🔍 StackTrace ↓↓↓", e);
+
+      // JPA 수동 롤백 (저장한 영화 ID 삭제)
+      try {
+        jpaService.deleteFromJpaById(dto.getId());
+        log.warn("🧹 JPA 저장 내용 수동 롤백 완료: ID={}", dto.getId());
+      } catch (Exception rollbackEx) {
+        log.error("❗ JPA 수동 롤백 중 예외 발생", rollbackEx);
+      }
+
+      throw new RuntimeException("Neo4j 저장 실패로 인한 JPA 롤백 처리 완료", e);
     }
   }
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/service/jpa/UpcomingMovieSaveJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/service/jpa/UpcomingMovieSaveJpaService.java
@@ -7,6 +7,7 @@ import com.grepp.smartwatcha.infra.jpa.entity.MovieEntity;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -22,13 +23,46 @@ public class UpcomingMovieSaveJpaService {
   private final UpcomingMovieMapper upcomingMovieMapper;
 
   public void saveToJpa(UpcomingMovieDto dto) {
-    boolean exists = upcomingMovieJpaRepository.existsById(dto.getId());
-    //log.info("[saveToJpa] 저장 시도: {} (id: {}), exists? {}", dto.getTitle(), dto.getId(), exists);
-    if (!exists) {
-      MovieEntity entity = upcomingMovieMapper.toJpaEntity(dto);
+    try {
+      boolean exists = upcomingMovieJpaRepository.existsById(dto.getId());
+
+      if (!exists) {
+        MovieEntity entity = upcomingMovieMapper.toJpaEntity(dto);
+        upcomingMovieJpaRepository.save(entity);
+        log.info("✅ [saveToJpa] 저장 완료: {} (id: {})", dto.getTitle(), dto.getId());
+      } else {
+        log.info("⚠️ [saveToJpa] 중복 스킵: {} (id: {})", dto.getTitle(), dto.getId());
+        updateToJpa(dto);
+      }
+
+    } catch (DataIntegrityViolationException e) {
+      log.warn("⚠️ [saveToJpa] 중복 저장 시도 감지됨: {} (id: {})", dto.getTitle(), dto.getId());
+    }
+  }
+
+  public void updateToJpa(UpcomingMovieDto dto) {
+    upcomingMovieJpaRepository.findById(dto.getId()).ifPresentOrElse(entity -> {
+      entity.setTitle(dto.getTitle());
+      entity.setReleaseDate(dto.getReleaseDateTime());
+      entity.setOverview(dto.getOverview());
+      entity.setCertification(dto.getCertification());
+      entity.setPoster(dto.getPosterPath());
+      entity.setCountry(dto.getCountry());
+      entity.setIsReleased(false); // 동기화 대상은 항상 미공개 상태
+
       upcomingMovieJpaRepository.save(entity);
+      log.info("🆙 [updateToJpa] 업데이트 완료: {} (id: {})", dto.getTitle(), dto.getId());
+    }, () -> {
+      log.warn("❌ [updateToJpa] 존재하지 않는 영화로 업데이트 시도됨: ID={}", dto.getId());
+    });
+  }
+
+  public void deleteFromJpaById(Long id) {
+    if (upcomingMovieJpaRepository.existsById(id)) {
+      upcomingMovieJpaRepository.deleteById(id);
+      log.warn("🧹 [deleteFromJpaById] 삭제 완료: ID={}", id);
     } else {
-     // log.info("[saveToJpa] 중복으로 스킵: {} (id: {})", dto.getTitle(), dto.getId());
+      log.warn("❓ [deleteFromJpaById] 삭제 대상 없음: ID={}", id);
     }
   }
 

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/service/jpa/UpcomingMovieSyncTimeJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/service/jpa/UpcomingMovieSyncTimeJpaService.java
@@ -11,15 +11,16 @@ import org.springframework.stereotype.Service;
 public class UpcomingMovieSyncTimeJpaService {
   private final UpcomingMovieSyncTimeJpaRepository upcomingMovieSyncTimeJpaRepository;
 
-  public void update(String type, int newlyAddedCount, int failedCount){
-    upcomingMovieSyncTimeJpaRepository.save(
-        SyncTimeEntity.builder()
-            .type(type)
-            .syncTime(LocalDateTime.now())
-            .newlyAddedCount(newlyAddedCount)
-            .failedCount(failedCount)
-            .build()
-    );
+  public void update(String type, int newlyAddedCount, int failedCount, int enrichFailed){
+    SyncTimeEntity entity = upcomingMovieSyncTimeJpaRepository.findById(type)
+        .orElse(SyncTimeEntity.builder().type(type).build());
+
+    entity.setSyncTime(LocalDateTime.now());
+    entity.setNewlyAddedCount(newlyAddedCount);
+    entity.setFailedCount(failedCount);
+    entity.setEnrichFailedCount(enrichFailed);
+
+    upcomingMovieSyncTimeJpaRepository.save(entity);
   }
 
   public LocalDateTime getLastSyncTime(String type){

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/service/neo4j/UpcomingMovieGenreFetchNeo4jService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/service/neo4j/UpcomingMovieGenreFetchNeo4jService.java
@@ -7,9 +7,11 @@ import jakarta.annotation.PostConstruct;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UpcomingMovieGenreFetchNeo4jService {
@@ -19,20 +21,27 @@ public class UpcomingMovieGenreFetchNeo4jService {
   @Value("${tmdb.api.key}")
   private String apiKey;
 
-  private final Map<Integer, String> genreMap = new HashMap<>();
+  private final Map<Long, String> genreMap = new HashMap<>();
 
   @PostConstruct
   public void init() {
-    UpcomingMovieGenreApiResponse response = movieGenreApi.getGenres(apiKey, "en");
+    try {
+      UpcomingMovieGenreApiResponse response = movieGenreApi.getGenres(apiKey, "en");
 
-    if (response != null || response.getGenres() != null) {
-      for(UpcomingMovieGenreDto genre : response.getGenres()) {
-        genreMap.put(genre.getId(), genre.getName());
+      if (response != null && response.getGenres() != null) {
+        for (UpcomingMovieGenreDto genre : response.getGenres()) {
+          genreMap.put(genre.getId(), genre.getName());
+        }
+        log.info("✅ [장르 초기화] {}개 장르 로드 완료", genreMap.size());
+      } else {
+        log.warn("⚠️ [장르 초기화] 응답이 비어 있거나 장르가 없습니다.");
       }
+    } catch (Exception e) {
+      log.error("❌ [장르 초기화] TMDB 장르 API 호출 중 예외 발생", e);
     }
   }
 
-  public Map<Integer, String> getGenreMap() {
+  public Map<Long, String> getGenreMap() {
     return genreMap;
   }
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/service/neo4j/UpcomingMovieGenreMergeHelper.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/service/neo4j/UpcomingMovieGenreMergeHelper.java
@@ -16,8 +16,8 @@ public class UpcomingMovieGenreMergeHelper {
 
   private final UpcomingMovieGenreFetchNeo4jService genreFetchService;
 
-  public List<GenreNode> mergeGenres(List<GenreNode> existing, List<Integer> incomingGenreIds) {
-    Map<Integer, String> genreMap = genreFetchService.getGenreMap();
+  public List<GenreNode> mergeGenres(List<GenreNode> existing, List<Long> incomingGenreIds) {
+    Map<Long, String> genreMap = genreFetchService.getGenreMap();
 
     Set<String> incomingNames = incomingGenreIds.stream()
         .map(genreMap::get)

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/service/neo4j/UpcomingMovieSaveNeo4jService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/movie/upcoming/service/neo4j/UpcomingMovieSaveNeo4jService.java
@@ -3,11 +3,16 @@ package com.grepp.smartwatcha.app.model.admin.movie.upcoming.service.neo4j;
 import com.grepp.smartwatcha.app.model.admin.movie.upcoming.dto.UpcomingMovieDto;
 import com.grepp.smartwatcha.app.model.admin.movie.upcoming.mapper.UpcomingMovieMapper;
 import com.grepp.smartwatcha.app.model.admin.movie.upcoming.repository.neo4j.UpcomingMovieNeo4jRepository;
-import com.grepp.smartwatcha.infra.neo4j.node.*;
+import com.grepp.smartwatcha.infra.neo4j.node.ActorNode;
+import com.grepp.smartwatcha.infra.neo4j.node.DirectorNode;
+import com.grepp.smartwatcha.infra.neo4j.node.GenreNode;
+import com.grepp.smartwatcha.infra.neo4j.node.MovieNode;
+import com.grepp.smartwatcha.infra.neo4j.node.WriterNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -24,59 +29,54 @@ public class UpcomingMovieSaveNeo4jService {
   public void saveToNeo4j(UpcomingMovieDto dto) {
     Optional<MovieNode> optional = movieRepository.findById(dto.getId());
 
+    MovieNode toSave;
     if (optional.isPresent()) {
+      // 기존 노드 + 관계 읽어오기
       MovieNode existing = optional.get();
+      log.info("🔁[saveToNeo4j] 병합 저장 시도: {}", dto.getTitle());
 
-      existing.setActors(mergeActors(existing.getActors(), dto.getActorNames()));
-      existing.setDirectors(mergeDirectors(existing.getDirectors(), dto.getDirectorNames()));
-      existing.setWriters(mergeWriters(existing.getWriters(), dto.getWriterNames()));
+      // merge logic
+      existing.setActors(mergeNames(existing.getActors(), dto.getActorNames(), ActorNode::new));
+      existing.setDirectors(mergeNames(existing.getDirectors(), dto.getDirectorNames(), DirectorNode::new));
+      existing.setWriters(mergeNames(existing.getWriters(), dto.getWriterNames(), WriterNode::new));
       existing.setGenres(genreMergeHelper.mergeGenres(existing.getGenres(), dto.getGenreIds()));
 
-      //log.info("🔁 [Neo4j 병합 저장 시도] 영화 ID: {}, 제목: {}, 인증등급: {}, 타입: {}, 국가: {}", dto.getId(), dto.getTitle(), dto.getCertification(), dto.getReleaseType(), dto.getCountry());
-      movieRepository.save(existing);
-      //log.info("✅ [Neo4j 병합 저장 완료] 영화 ID: {}", dto.getId());
+      toSave = existing;
+
     } else {
-      List<GenreNode> genreNodes = genreMergeHelper.mergeGenres(new ArrayList<>(), dto.getGenreIds());
+      // 새 노드 + 관계 생성
+      log.info("🆕 [saveToNeo4j] 신규 저장 시도: {}", dto.getTitle());
+      List<ActorNode>   actors   = dto.getActorNames().stream().map(ActorNode::new).toList();
+      List<DirectorNode> directors = dto.getDirectorNames().stream().map(DirectorNode::new).toList();
+      List<WriterNode>   writers  = dto.getWriterNames().stream().map(WriterNode::new).toList();
+      List<GenreNode>    genres   = genreMergeHelper.mergeGenres(Collections.emptyList(), dto.getGenreIds());
 
-      MovieNode node = upcomingMovieMapper.toNeo4jNode(
-          dto,
-          dto.getActorNames().stream().map(ActorNode::new).toList(),
-          dto.getDirectorNames().stream().map(DirectorNode::new).toList(),
-          dto.getWriterNames().stream().map(WriterNode::new).toList(),
-          genreNodes
-      );
-
-      //log.info("🔁 [Neo4j 저장 시도] 영화 ID: {}, 제목: {}, 인증등급: {}, 타입: {}, 국가: {}", dto.getId(), dto.getTitle(), dto.getCertification(), dto.getReleaseType(), dto.getCountry());
-      movieRepository.save(node);
-      //log.info("✅ [Neo4j 저장 완료] 영화 ID: {}", dto.getId());
+      toSave = upcomingMovieMapper.toNeo4jNode(dto, actors, directors, writers, genres);
     }
+
+    // MovieNode 하나만 save — 관계까지 전부 반영
+    movieRepository.save(toSave);
+    log.info("✅ [saveToNeo4j] 저장 완료: {} (ID={})", toSave.getTitle(), toSave.getId());
   }
 
-  private List<ActorNode> mergeActors(List<ActorNode> existing, List<String> incoming) {
-    Set<String> names = existing.stream().map(ActorNode::getName).collect(Collectors.toSet());
-    for (String name : incoming) {
-      if (!names.contains(name)) {
-        existing.add(new ActorNode(name));
-      }
-    }
-    return existing;
-  }
+  // Generic merge helper
+  private <N> List<N> mergeNames(
+      List<N> existing, List<String> incoming, java.util.function.Function<String, N> ctor
+  ) {
+    Set<String> names = existing.stream()
+        .map(n -> {
+          try {
+            // ActorNode#getName(), DirectorNode#getName() 등
+            return (String) n.getClass().getMethod("getName").invoke(n);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        })
+        .collect(Collectors.toSet());
 
-  private List<DirectorNode> mergeDirectors(List<DirectorNode> existing, List<String> incoming) {
-    Set<String> names = existing.stream().map(DirectorNode::getName).collect(Collectors.toSet());
     for (String name : incoming) {
       if (!names.contains(name)) {
-        existing.add(new DirectorNode(name));
-      }
-    }
-    return existing;
-  }
-
-  private List<WriterNode> mergeWriters(List<WriterNode> existing, List<String> incoming) {
-    Set<String> names = existing.stream().map(WriterNode::getName).collect(Collectors.toSet());
-    for (String name : incoming) {
-      if (!names.contains(name)) {
-        existing.add(new WriterNode(name));
+        existing.add(ctor.apply(name));
       }
     }
     return existing;

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/AdminTagJpaRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/AdminTagJpaRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AdminTagJpaRespository extends JpaRepository<TagEntity, Long> {
+public interface AdminTagJpaRepository extends JpaRepository<TagEntity, Long> {
   List<TagEntity> findAll();
   Page<TagEntity> findByNameContainingIgnoreCase(String keyword, Pageable pageable);
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/AdminTagService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/tag/AdminTagService.java
@@ -10,13 +10,13 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AdminTagService {
 
-  private final AdminTagJpaRespository adminTagJpaRespository;
+  private final AdminTagJpaRepository adminTagJpaRepository;
 
   public Page<TagEntity> findTagsByKeyword(String keyword, Pageable pageable) {
     if  (keyword == null || keyword.isBlank()){
-      return adminTagJpaRespository.findAll(pageable);
+      return adminTagJpaRepository.findAll(pageable);
     } else {
-      return adminTagJpaRespository.findByNameContainingIgnoreCase(keyword, pageable);
+      return adminTagJpaRepository.findByNameContainingIgnoreCase(keyword, pageable);
     }
   }
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/code/AdminUserSpecifications.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/code/AdminUserSpecifications.java
@@ -1,6 +1,7 @@
 package com.grepp.smartwatcha.app.model.admin.user.code;
 
 import com.grepp.smartwatcha.infra.jpa.entity.UserEntity;
+import com.grepp.smartwatcha.infra.jpa.enums.Role;
 import org.springframework.data.jpa.domain.Specification;
 
 public class AdminUserSpecifications {
@@ -10,9 +11,9 @@ public class AdminUserSpecifications {
             cb.like(cb.lower(root.get("name")), "%" + name.toLowerCase() + "%");
   }
 
-  public static Specification<UserEntity> hasRole(String role){
+  public static Specification<UserEntity> hasRole(Role role){
     return (root, query, cb) ->
-        (role == null || role.isBlank()) ? null :
+        (role == null) ? null :
             cb.equal(root.get("role"), role);
   }
 

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/mapper/AdminUserMapper.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/mapper/AdminUserMapper.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 public class AdminUserMapper {
   public static AdminUserListResponseDto toDto(UserEntity user, List<AdminSimpleRatingDto> recentRatings) {
+    LocalDateTime now = LocalDateTime.now();
     AdminUserListResponseDto dto = AdminUserListResponseDto.builder()
         .id(user.getId())
         .name(user.getName())
@@ -20,8 +21,8 @@ public class AdminUserMapper {
         .recentRatings(recentRatings)
         .build();
 
-    boolean isRecentlyModified = user.getModifiedAt() != null && user.getModifiedAt().isAfter(LocalDateTime.now().minusDays(3));
-    dto.setUpdatedRecently(isRecentlyModified);
+    boolean isRecentlyModified = user.getModifiedAt() != null &&
+        user.getModifiedAt().isAfter(now.minusDays(3));
 
     return dto;
   }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/service/AdminUserRatingJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/service/AdminUserRatingJpaService.java
@@ -3,10 +3,10 @@ package com.grepp.smartwatcha.app.model.admin.user.service;
 import com.grepp.smartwatcha.app.model.admin.user.dto.AdminRatingDto;
 import com.grepp.smartwatcha.app.model.admin.user.repository.AdminUserRatingJpaRepository;
 import com.grepp.smartwatcha.infra.jpa.entity.RatingEntity;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -17,20 +17,19 @@ public class AdminUserRatingJpaService {
   private final AdminUserRatingJpaRepository ratingRepository;
 
   public Page<AdminRatingDto> getRatings(Long userId, Pageable pageable) {
+    Page<RatingEntity> ratingPage = (userId != null)
+        ? ratingRepository.findAllByUserId(userId, pageable)
+        : ratingRepository.findAll(pageable);
 
-    Page<RatingEntity> ratingPage;
+    return ratingPage.map(this::toDto);
+  }
 
-    if (userId != null) {
-      ratingPage = ratingRepository.findAllByUserId(userId, pageable);
-    } else {
-      ratingPage = ratingRepository.findAll(pageable);
-    }
-
-    return ratingPage.map((RatingEntity rating) -> AdminRatingDto.builder()
+  private AdminRatingDto toDto(RatingEntity rating) {
+    return AdminRatingDto.builder()
         .title(rating.getMovie().getTitle())
         .score(rating.getScore())
         .createdAt(rating.getCreatedAt())
         .userName(rating.getUser().getName())
-        .build());
+        .build();
   }
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/infra/jpa/entity/SyncTimeEntity.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/infra/jpa/entity/SyncTimeEntity.java
@@ -24,5 +24,8 @@ public class SyncTimeEntity {
   private LocalDateTime syncTime;
 
   private int newlyAddedCount;
+
   private int failedCount;
+
+  private Integer enrichFailedCount;
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/infra/neo4j/node/ActorNode.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/infra/neo4j/node/ActorNode.java
@@ -15,4 +15,19 @@ public class ActorNode {
     @Id
     private final String name;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof ActorNode))
+            return false;
+        ActorNode that = (ActorNode) o;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
 }
+

--- a/backend/src/main/java/com/grepp/smartwatcha/infra/neo4j/node/DirectorNode.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/infra/neo4j/node/DirectorNode.java
@@ -14,4 +14,17 @@ public class DirectorNode {
 
     @Id
     private final String name;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DirectorNode)) return false;
+        DirectorNode that = (DirectorNode) o;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/infra/neo4j/node/GenreNode.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/infra/neo4j/node/GenreNode.java
@@ -14,4 +14,17 @@ public class GenreNode {
 
     @Id
     private final String name;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GenreNode)) return false;
+        GenreNode that = (GenreNode) o;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/infra/neo4j/node/WriterNode.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/infra/neo4j/node/WriterNode.java
@@ -14,4 +14,17 @@ public class WriterNode {
 
     @Id
     private final String name;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof WriterNode)) return false;
+        WriterNode that = (WriterNode) o;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
 }

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -25,7 +25,7 @@
             display: flex;
             flex-wrap: wrap;
             gap: 1rem;
-            margin-bottom: 2rem;
+            margin-bottom: 1rem;
         }
 
         .card {
@@ -74,6 +74,7 @@
         .half-section {
             flex: 1;
             min-width: 280px;
+            margin-bottom: 25px;
         }
     </style>
 </head>
@@ -100,7 +101,15 @@
             <h5>🕒 Recent Upcoming Sync</h5>
             <p>📅 Last Sync Time: <span th:text="${#temporals.format(lastSyncTime, 'yyyy-MM-dd HH:mm:ss')}">N/A</span></p>
             <p>📥 New Movies Added: <strong th:text="${newlyAddedCount}">0</strong></p>
-            <p>⚠️ Failed: <strong th:text="${failedCount}">0</strong></p>
+            <p>
+                ⚠️ Failed:
+                <strong th:class="${failedCount > 0} ? 'red-text' : ''" th:text="${failedCount}">0</strong>
+            </p>
+
+            <p>🔍 Enrich Failed: <strong th:text="${enrichFailedCount}">0</strong></p>
+            <button type="button" class="waves-effect" onclick="syncUpcomingMovies()" style="background-color: #ff6262; color: white; border: none; padding: 6px 12px; border-radius: 4px;
+        font-size: 0.95rem; line-height: 1.2; display: flex; align-items: center; gap: 6px;"><i class="material-icons" style="font-size: 1.1rem;">cached</i>Manual Sync
+            </button>
         </div>
 
         <!-- 🎬 공개 예정 영화 목록 -->
@@ -147,7 +156,7 @@
                     </div>
                 </li>
             </ul>
-            <a href="/admin/movies/upcoming" style="margin-top:1rem; display:inline-block; color: lightcoral;">➕ More</a>
+            <a href="/admin/movies/upcoming" style="display:inline-block; color: lightcoral;">➕ More</a>
         </div>
     </div>
 
@@ -168,6 +177,25 @@
         var elems = document.querySelectorAll('.modal');
         M.Modal.init(elems);
     });
+
+    function syncUpcomingMovies() {
+        fetch('/admin/movies/upcoming/sync-manual-test', {
+            method: 'GET'
+        })
+        .then(res => {
+            console.log("응답 상태:", res.status);
+            if (res.ok) {
+                alert("✅ Sync completed successfully!");
+                window.location.href = '/admin/movies/upcoming?v=' + new Date().getTime();
+            } else {
+                alert("❌ Sync failed! (" + res.status + ")");
+            }
+        })
+        .catch(err => {
+            console.error(err);
+            alert("⚠️ An error occurred!");
+        });
+    }
 </script>
 </section>
 </body>


### PR DESCRIPTION
## 📌 과제 설명
- 공개 예정작 neo4j에 저장 되지 않았던 문제 해결
- 공개 예정작 병렬 호출 로직 안정화 및 예외처리 보완
- enrich 실패 시에도 전체 동기화가 중단되지 않도록 로직 개선
- 관리자 대시보드 enrich 실패 건수 표시 및 UI 개선
- 영화/사용자 관리 페이지에서 필터/예외 처리 보완

## 👩‍💻 요구 사항과 구현 내용

### ✅ 공개 예정작 동기화 개선
- `UpcomingMovieFetchService`: 병렬 API 호출 시 예외 발생해도 전체 흐름 유지
- `UpcomingMovieUnifiedSaveService`: Neo4j 저장 실패 시 JPA 저장 수동 롤백
- `UpcomingMovieSyncScheduler`: enrich 실패 수 및 이유 로깅 추가
- `SyncTimeEntity`: `enrichFailedCount` 필드 추가
- `UpcomingMovieSyncTimeJpaService`: enrich 실패 건수 저장 기능 추가

### ✅ 관리자 대시보드 개선
- `AdminController`, `dashboard.html`: enrich 실패 건수 UI 출력 추가
- `AdminDashboardJpaService`: enrich 실패 건수 조회 기능 추가

### ✅ 사용자 관리
- `AdminUserJpaService`: role 파라미터 타입 변경 (String → enum)
- 예외 메시지 명확화, 최근 평가 리스트 분리하여 재사용성 개선

### ✅ 영화 관리
- `AdminMovieJpaService`: 날짜 키워드 파싱 로직 개선
- `AdminMovieMapper`: `LocalDateTime.now()` 분리하여 최근 수정 여부 판단

### ✅ Neo4j 관계 노드 병합 개선
- `WriterNode`, `ActorNode` 등 관계 노드에 `equals` / `hashCode` 오버라이딩
- `mergeNames()` 메서드 제네릭으로 리팩토링
- `genreIds` 타입 Integer → Long 일괄 수정

+ AdminTagJpaRepository 클래스명 오타 수정

## ✅ 피드백 반영사항
- 공개 예정작 저장 중 관계 노드 중복으로 인한 `IncorrectResultSizeDataAccessException` 및 `NoSuchRecordException` 발생
- 관계 노드에 `equals`, `hashCode` 구현하여 중복 제거
- `findById()` 기반 병합 방식 유지하되, `mergeGenres`, `mergeNames` 방식으로 관계 안정적 병합 처리
  

## ✅ PR 포인트 & 궁금한 점
- enrich 실패 시 전체 프로세스를 멈추지 않고 통계만 누적하는 방향이 적절한지 검토 부탁드립니다.
- 대시보드 enrich 실패 외에도 유용할 통계 항목이 있다면 제안 부탁드립니다.
- 장르 ID 타입을 Integer → Long으로 변경했는데, 그 외에도 타입 일관성을 더 봐야 할 부분이 있다면 알려주세요.
