### PR TITLE
Feat: 장르 일치 작품 목록 추가 및 상세페이지 화면 개선

### DIFF
--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/details/InterestApiController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/details/InterestApiController.java
@@ -29,5 +29,12 @@ public class InterestApiController {
         interestJpaService.saveOrUpdateInterest(userEmail, movieId, status);
         return ResponseEntity.ok().build();
     }
+    @DeleteMapping
+    public ResponseEntity<Void> deleteInterest(@PathVariable("id") Long movieId,
+                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUser().getId();
+        interestJpaService.deleteInterest(userId, movieId);
+        return ResponseEntity.noContent().build(); // 204 응답
+    }
 }
 

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/details/InterestApiController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/details/InterestApiController.java
@@ -34,7 +34,7 @@ public class InterestApiController {
                                                @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails.getUser().getId();
         interestJpaService.deleteInterest(userId, movieId);
-        return ResponseEntity.noContent().build(); // 204 응답
+        return ResponseEntity.noContent().build();
     }
 }
 

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/details/RatingApiController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/details/RatingApiController.java
@@ -31,6 +31,13 @@ public class RatingApiController {
         ratingJpaService.addRating(dto);
         return ResponseEntity.ok("평점이 성공적으로 등록되었습니다.");
     }
+    @DeleteMapping
+    public ResponseEntity<Void> deleteRating(@PathVariable("id") Long movieId,
+                                             @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUser().getId();
+        ratingJpaService.deleteRatingByUser(userId, movieId);
+        return ResponseEntity.noContent().build(); // 204 No Content 반환
+    }
     @GetMapping("/average")
     public ResponseEntity<Double> getAverageRating(
             @PathVariable("id") Long movieId) {
@@ -42,5 +49,6 @@ public class RatingApiController {
     public List<RatingBarDto> getRatingBars(@PathVariable("id") Long movieId) {
         return ratingJpaService.getRatingDistributionList(movieId);
     }
+
 
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/details/MovieDetailsController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/web/details/MovieDetailsController.java
@@ -3,7 +3,9 @@ package com.grepp.smartwatcha.app.controller.web.details;
 import com.grepp.smartwatcha.app.model.auth.CustomUserDetails;
 import com.grepp.smartwatcha.app.model.details.dto.jpadto.MovieDetailsDTO;
 import com.grepp.smartwatcha.app.model.details.dto.jpadto.RatingBarDto;
+import com.grepp.smartwatcha.app.model.details.dto.jpadto.SimilarMovieDto;
 import com.grepp.smartwatcha.app.model.details.dto.neo4jdto.Neo4jTagDto;
+import com.grepp.smartwatcha.app.model.details.service.GenreRecommendService;
 import com.grepp.smartwatcha.app.model.details.service.jpaservice.InterestJpaService;
 import com.grepp.smartwatcha.app.model.details.service.jpaservice.MovieJpaService;
 import com.grepp.smartwatcha.app.model.details.service.jpaservice.RatingJpaService;
@@ -33,6 +35,8 @@ public class MovieDetailsController {
     private final MovieNeo4jService movieNeo4jService;
     private final TagNeo4jService tagNeo4jService;
     private final InterestJpaService interestJpaService;
+    private final GenreRecommendService genreRecommendService;
+
 
     @GetMapping("/{id}")
     public String getMovieDetail(
@@ -45,11 +49,15 @@ public class MovieDetailsController {
         MovieNode neo4jMovie = movieNeo4jService.getMovieWithAllRelations(id);
         List<Neo4jTagDto> topTags = tagNeo4jService.getTop6Tags(id);
 
+        List<SimilarMovieDto> similarMovies = genreRecommendService.getGenreSimilarMovies(id);
+
+
         // mysql db
         model.addAttribute("movie", movie);
         model.addAttribute("averageScore", averageScore);
         model.addAttribute("ratingDistribution", ratingDistribution);
         model.addAttribute("ratingBars", ratingList);
+        model.addAttribute("similarMovies", similarMovies);
 
         // neo4j db
         model.addAttribute("no4jMovie", neo4jMovie);

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/details/dto/jpadto/SimilarMovieDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/details/dto/jpadto/SimilarMovieDto.java
@@ -1,0 +1,16 @@
+package com.grepp.smartwatcha.app.model.details.dto.jpadto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SimilarMovieDto {
+    private Long id;
+    private String title;
+    private String poster;
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/details/repository/jparepository/InterestJpaRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/details/repository/jparepository/InterestJpaRepository.java
@@ -18,4 +18,5 @@ public interface InterestJpaRepository extends JpaRepository<InterestEntity, Lon
 
     Optional<InterestEntity> findByUserIdAndMovieId(Long userId, Long movieId);
 
+    void deleteByUserIdAndMovieId(Long userId, Long movieId);
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/details/repository/jparepository/MovieDetailsJpaRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/details/repository/jparepository/MovieDetailsJpaRepository.java
@@ -5,9 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface MovieDetailsJpaRepository extends JpaRepository<MovieEntity, Long> {
 
     @Query("SELECT AVG(r.score) FROM RatingEntity r WHERE r.movie.id = :movieId")
     Double findAverageScore(@Param("movieId") Long movieId);
+
+    List<MovieEntity> findByIdIn(List<Long> movieIds);
 }
 

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/details/repository/jparepository/RatingJpaRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/details/repository/jparepository/RatingJpaRepository.java
@@ -27,4 +27,7 @@ public interface RatingJpaRepository extends JpaRepository<RatingEntity, Long> {
 
     @Query("SELECT r FROM RatingEntity r WHERE r.user.id = :userId AND r.movie.id = :movieId")
     Optional<RatingEntity> findRatingByUserAndMovie(@Param("userId") Long userId, @Param("movieId") Long movieId);
+
+    void deleteByUserIdAndMovieId(Long userId, Long movieId);
+
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/details/repository/neo4jrepository/DetailsNeo4jRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/details/repository/neo4jrepository/DetailsNeo4jRepository.java
@@ -2,11 +2,22 @@ package com.grepp.smartwatcha.app.model.details.repository.neo4jrepository;
 
 import com.grepp.smartwatcha.infra.neo4j.node.MovieNode;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
+import org.springframework.data.neo4j.repository.query.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface DetailsNeo4jRepository extends Neo4jRepository<MovieNode, Long> {
     Optional<MovieNode> findById(Long movieId);
+
+    @Query("""
+MATCH (m:MOVIE {id: $movieId})-[:HAS_GENRE]->(g:GENRE)<-[:HAS_GENRE]-(other:MOVIE)
+WHERE other.id <> $movieId
+RETURN DISTINCT other.id
+LIMIT 10
+""")
+    List<Long> findSimilarMoviesByGenre(Long movieId);
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/details/service/GenreRecommendService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/details/service/GenreRecommendService.java
@@ -1,0 +1,27 @@
+package com.grepp.smartwatcha.app.model.details.service;
+
+
+import com.grepp.smartwatcha.app.model.details.dto.jpadto.SimilarMovieDto;
+import com.grepp.smartwatcha.app.model.details.service.jpaservice.MovieRecommendService;
+import com.grepp.smartwatcha.app.model.details.service.neo4jservice.MovieNeo4jService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GenreRecommendService {
+    private final MovieNeo4jService movieNeo4jService;
+    private final MovieRecommendService movieRecommendService;
+
+    public List<SimilarMovieDto> getGenreSimilarMovies(Long movieId) {
+        List<Long> similarIds = movieNeo4jService.findSimilarMovieIds(movieId);
+
+        if (similarIds.isEmpty()) return Collections.emptyList();
+
+        return movieRecommendService.getMoviesByIds(similarIds);
+    }
+}
+

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/details/service/jpaservice/InterestJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/details/service/jpaservice/InterestJpaService.java
@@ -39,4 +39,7 @@ public class InterestJpaService {
                 .map(InterestEntity::getStatus)
                 .orElse(null);
     }
+    public void deleteInterest(Long userId, Long movieId) {
+        interestJpaRepository.deleteByUserIdAndMovieId(userId, movieId);
+    }
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/details/service/jpaservice/MovieRecommendService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/details/service/jpaservice/MovieRecommendService.java
@@ -1,0 +1,23 @@
+package com.grepp.smartwatcha.app.model.details.service.jpaservice;
+
+import com.grepp.smartwatcha.app.model.details.dto.jpadto.SimilarMovieDto;
+import com.grepp.smartwatcha.app.model.details.repository.jparepository.MovieDetailsJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(transactionManager = "jpaTransactionManager")
+public class MovieRecommendService {
+    private final MovieDetailsJpaRepository movieDetailsJpaRepository;
+
+    public List<SimilarMovieDto> getMoviesByIds(List<Long> ids) {
+        return movieDetailsJpaRepository.findByIdIn(ids).stream()
+                .map(m -> new SimilarMovieDto(m.getId(),m.getTitle(),m.getPoster()))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/details/service/jpaservice/RatingJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/details/service/jpaservice/RatingJpaService.java
@@ -78,4 +78,10 @@ public class RatingJpaService {
                 .map(r -> r.getScore() != null ? r.getScore().intValue() : null)
                 .orElse(null);
     }
+
+    public void deleteRatingByUser(Long userId, Long movieId) {
+        ratingJpaRepository.deleteByUserIdAndMovieId(userId, movieId);
+    }
+
+
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/details/service/neo4jservice/MovieNeo4jService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/details/service/neo4jservice/MovieNeo4jService.java
@@ -5,6 +5,8 @@ import com.grepp.smartwatcha.infra.neo4j.node.MovieNode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class MovieNeo4jService {
@@ -13,5 +15,8 @@ public class MovieNeo4jService {
     public MovieNode getMovieWithAllRelations(Long movieId) {
         return movieNeo4jRepository.findById(movieId)
                 .orElseThrow(() -> new RuntimeException("Movie not found in Neo4j"));
+    }
+    public List<Long> findSimilarMovieIds(Long movieId) {
+        return movieNeo4jRepository.findSimilarMoviesByGenre(movieId);
     }
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/infra/jpa/entity/MovieTagEntity.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/infra/jpa/entity/MovieTagEntity.java
@@ -1,10 +1,10 @@
 package com.grepp.smartwatcha.infra.jpa.entity;
 
+import com.grepp.smartwatcha.infra.jpa.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
-
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -13,22 +13,22 @@ import java.time.LocalDateTime;
 @Builder
 @Entity
 @Table(name = "movie_tag")
-public class MovieTagEntity {
+public class MovieTagEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne
-    private MovieEntity movie;
-
-    @ManyToOne
     private TagEntity tag;
 
-    @ManyToOne
-    private UserEntity user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "movie_id")
+    private MovieEntity movie;
 
-    private LocalDateTime createdAt;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
 
     public MovieTagEntity(UserEntity user, MovieEntity movie, TagEntity tag) {
         this.user = user;

--- a/backend/src/main/resources/templates/movie/guest-details.html
+++ b/backend/src/main/resources/templates/movie/guest-details.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org"  lang="en" >
 <head>
     <title th:text="${movie.title}">영화 상세 페이지</title>
+    <th:block th:replace="fragments :: frg_static"></th:block>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <style>
         body {
@@ -72,47 +73,6 @@
         .overlay {
             background-color: rgba(0, 0, 0, 0.85);
             min-height: 100vh;
-        }
-
-        nav {
-            background-color: #1e1e1e;
-            padding: 15px 30px;
-
-            display: flex;
-            justify-content: center;
-        }
-        .nav-content {
-            width: 100%;
-            max-width: 1200px;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-        .nav-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: white;
-            text-decoration: none;
-        }
-
-        .nav-menu a {
-            color: white;
-            text-decoration: none;
-            margin-left: 20px;
-            font-size: 16px;
-        }
-
-        .nav-menu a.logout {
-            color: red;
-        }
-        nav a {
-            color: white;
-            text-decoration: none;
-            margin-left: 20px;
-        }
-
-        nav a:last-child {
-            color: red;
         }
 
         .main-section {
@@ -233,11 +193,19 @@
         }
 
         .tag-selection {
-            margin-top: 30px;
-            margin-bottom: 10px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
         }
 
-        #tagInput {
+        .tag-selection label {
+            font-size: 16px;
+            font-weight: bold;
+            color: white;
+            white-space: nowrap;
+        }
+
+        input#tagInput[type="text"] {
             border: none;
             outline: none;
             box-shadow: none;
@@ -245,6 +213,14 @@
             color: black;
             padding: 6px 10px;
             border-radius: 4px;
+            width: 180px !important;
+            flex-shrink: 0;
+        }
+        #submitTag {
+            white-space: nowrap;
+            height: 30px;
+            padding: 0 5px;
+            font-size: 10px;
         }
 
         .top-tags ul {
@@ -316,10 +292,17 @@
             font-size: 28px;
             cursor: pointer;
         }
+        h3, h4 {
+            font-size: 18px;
+            font-weight: bold;
+            margin: 10px 0;
+            color: white;
+        }
+
     </style>
 </head>
-<body th:attr="data-movie-id=${movie.id}, data-user-id='1'">
-
+<body th:attr="data-movie-id=${movie.id}">
+<th:block th:replace="fragments :: frg_header"></th:block>
 <div id="login-banner" class="login-modal">
     <div class="login-modal-content">
         <span class="close" onclick="closeLoginBanner()">&times;</span>
@@ -331,22 +314,6 @@
 </div>
 
 <div class="overlay">
-
-    <nav>
-        <div class="nav-content">
-            <a href="/" class="nav-logo">
-                <i class="fa-solid fa-clapperboard" style="color: #a58efc;"></i> SmartMovie
-            </a>
-            <div class="nav-menu">
-                <a href="/">Home</a>
-                <a href="/search">Search</a>
-                <a href="/login" class="logout">Login</a>
-            </div>
-        </div>
-    </nav>
-
-
-
     <div class="main-section">
         <div class="poster">
             <img th:src="${movie.poster != null ? 'https://image.tmdb.org/t/p/w500' + movie.poster : '/images/default.jpg'}" alt="포스터">
@@ -407,7 +374,7 @@
 
             <div class="tag-selection">
                 <label for="tagInput"><strong>태그 남기기:</strong></label>
-                <input type="text" id="tagInput" placeholder="태그를 입력하세요..." autocomplete="off"/>
+                <input type="text" id="tagInput" class="browser-default" placeholder="태그를 입력하세요..." autocomplete="off"/>
                 <button id="submitTag">태그 남기기</button>
             </div>
 
@@ -521,5 +488,6 @@
         if (event.target === modal) closeLoginBanner();
     });
 </script>
+    <th:block th:replace="fragments :: frg_footer"></th:block>
 </body>
 </html>

--- a/backend/src/main/resources/templates/movie/guest-details.html
+++ b/backend/src/main/resources/templates/movie/guest-details.html
@@ -10,6 +10,64 @@
             background-color: #121212;
             color: #ffffff;
         }
+        .genre-recommend-container {
+            padding: 20px 0;
+        }
+
+        .slider-wrapper {
+            position: relative;
+            display: flex;
+            align-items: center;
+        }
+
+        .recommend-list {
+            display: flex;
+            overflow-x: auto;
+            gap: 20px;
+            scroll-behavior: smooth;
+            padding: 10px 0;
+            margin: 0 40px;
+        }
+        .recommend-list::-webkit-scrollbar {
+            display: none;
+        }
+
+        .recommend-item {
+            width: 120px;
+            flex-shrink: 0;
+            text-align: center;
+        }
+
+        .recommend-poster {
+            width: 100%;
+            border-radius: 8px;
+        }
+
+        .slider-button {
+            position: absolute;
+            z-index: 10;
+            width: 36px;
+            height: 36px;
+            border-radius: 50%;
+            border: none;
+            background-color: rgba(0, 0, 0, 0.5);
+            color: white;
+            font-size: 18px;
+            cursor: pointer;
+            transition: background-color 0.3s ease;
+        }
+
+        .slider-button.left {
+            left: 0;
+        }
+
+        .slider-button.right {
+            right: 0;
+        }
+
+        .slider-button:hover {
+            background-color: #27c29c;
+        }
 
         .overlay {
             background-color: rgba(0, 0, 0, 0.85);
@@ -383,6 +441,24 @@
             </div>
         </div>
     </div>
+    <div class="section-divider"></div>
+    <div style="max-width: 1200px; margin: 0 auto; padding: 0 30px;">
+    <div class="genre-recommend-container">
+        <h3 class="recommend-title">장르가 비슷한 작품:</h3>
+        <div class="slider-wrapper">
+            <button class="slider-button left" onclick="scrollToLeft(this)">&#10094;</button>
+            <div class="recommend-list" style="display: flex; overflow-x: auto; gap: 20px; padding-bottom: 10px; scrollbar-width: none; -ms-overflow-style: none;">
+                <div class="recommend-item" th:each="sim : ${similarMovies}">
+                    <a th:href="@{'/movies/' + ${sim.id}}">
+                        <img th:src="${sim.poster != null ? 'https://image.tmdb.org/t/p/w500' + sim.poster : '/images/default.jpg'}"
+                             alt="포스터" class="recommend-poster" />
+                    </a>
+                    <p class="recommend-title" th:text="${sim.title}">영화 제목</p>
+                </div>
+            </div>
+            <button class="slider-button right" onclick="scrollToRight(this)">&#10095;</button>
+        </div>
+    </div>
 </div>
 
 <script>
@@ -393,6 +469,16 @@
     function closeLoginBanner() {
         document.getElementById("login-banner").style.display = "none";
     }
+    function scrollToLeft(button) {
+        const list = button.parentElement.querySelector(".recommend-list");
+        list.scrollBy({ left: -300, behavior: 'smooth' });
+    }
+
+    function scrollToRight(button) {
+        const list = button.parentElement.querySelector(".recommend-list");
+        list.scrollBy({ left: 300, behavior: 'smooth' });
+    }
+
 
     document.addEventListener("DOMContentLoaded", () => {
         document.querySelectorAll(".stars").forEach(star => {

--- a/backend/src/main/resources/templates/movie/guest-details.html
+++ b/backend/src/main/resources/templates/movie/guest-details.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org"  lang="en" >
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
 <head>
     <title th:text="${movie.title}">영화 상세 페이지</title>
     <th:block th:replace="fragments :: frg_static"></th:block>
@@ -11,6 +11,7 @@
             background-color: #121212;
             color: #ffffff;
         }
+
         .genre-recommend-container {
             padding: 20px 0;
         }
@@ -29,6 +30,7 @@
             padding: 10px 0;
             margin: 0 40px;
         }
+
         .recommend-list::-webkit-scrollbar {
             display: none;
         }
@@ -216,11 +218,12 @@
             width: 180px !important;
             flex-shrink: 0;
         }
+
         #submitTag {
             white-space: nowrap;
             height: 30px;
             padding: 0 5px;
-            font-size: 10px;
+            font-size: 14px;
         }
 
         .top-tags ul {
@@ -292,6 +295,7 @@
             font-size: 28px;
             cursor: pointer;
         }
+
         h3, h4 {
             font-size: 18px;
             font-weight: bold;
@@ -299,6 +303,18 @@
             color: white;
         }
 
+        /* 모든 버튼 기본 focus 효과 제거 (불필요한 초록 테두리 제거) */
+        button:focus,
+        .icon-button:focus {
+            outline: none;
+            box-shadow: none;
+            background-color: transparent;
+        }
+
+        /* 슬라이더 버튼만 focus 시 초록색 배경 유지 */
+        .slider-button:focus {
+            background-color: #27c29c;
+        }
     </style>
 </head>
 <body th:attr="data-movie-id=${movie.id}">
@@ -312,11 +328,11 @@
         <button onclick="location.href='/user/signup'">회원가입</button>
     </div>
 </div>
-
 <div class="overlay">
     <div class="main-section">
         <div class="poster">
-            <img th:src="${movie.poster != null ? 'https://image.tmdb.org/t/p/w500' + movie.poster : '/images/default.jpg'}" alt="포스터">
+            <img th:src="${movie.poster != null ? 'https://image.tmdb.org/t/p/w500' + movie.poster : '/images/default.jpg'}"
+                 alt="포스터">
             <div class="graph">
                 <div th:each="bar : ${ratingBars}" class="bar-group">
                     <div class="bar-vertical" th:style="'height:' + (${bar.percent} * 10) + 'px'"></div>
@@ -324,7 +340,6 @@
                 </div>
             </div>
         </div>
-
         <div class="info-section">
             <div class="movie-title" th:text="${movie.title}">영화 제목</div>
             <div class="info-text">
@@ -332,7 +347,8 @@
                 <span th:each="genre : ${genres}" th:text="${genre.name} + ' '"></span>
             </div>
             <div class="info-text">
-                <span th:text="'개봉일: ' + (${movie.releaseDate} != null ? ${#temporals.format(movie.releaseDate, 'yyyy-MM-dd')} : '정보없음')"></span> |
+                <span th:text="'개봉일: ' + (${movie.releaseDate} != null ? ${#temporals.format(movie.releaseDate, 'yyyy-MM-dd')} : '정보없음')"></span>
+                |
                 <span th:text="'국가: ' + (${movie.country} != null ? ${movie.country} : '정보없음')"></span> |
                 <span th:text="'관람등급: ' + (${movie.certification} != null ? ${movie.certification} : '정보없음')"></span> |
                 <span th:text="'공개 여부: ' + (${movie.isReleased} ? '공개됨' : '미공개')"></span>
@@ -352,16 +368,13 @@
                     <div class="rating-left">
                         <strong>평가하기:</strong>
                         <span th:each="i : ${#numbers.sequence(1,5)}">
-                <i class="fa-regular fa-star stars" th:attr="data-score=${i}"></i>
-            </span>
+                        <i class="fa-regular fa-star stars" th:attr="data-score=${i}"></i></span>
                     </div>
-
                     <!-- 가운데: 평균 별점 -->
                     <div class="rating-center">
                         <strong th:text="${#numbers.formatDecimal(averageScore != null ? averageScore : 0.0, 1, 1)}">0.0</strong>
                         <div style="font-size: 14px; color: #ccc;">평균 별점</div>
                     </div>
-
                     <!-- 오른쪽: 아이콘 버튼 -->
                     <div class="rating-right">
                         <button class="icon-button"><i class="fa-solid fa-bookmark"></i> 보고싶어요</button>
@@ -410,24 +423,25 @@
     </div>
     <div class="section-divider"></div>
     <div style="max-width: 1200px; margin: 0 auto; padding: 0 30px;">
-    <div class="genre-recommend-container">
-        <h3 class="recommend-title">장르가 비슷한 작품:</h3>
-        <div class="slider-wrapper">
-            <button class="slider-button left" onclick="scrollToLeft(this)">&#10094;</button>
-            <div class="recommend-list" style="display: flex; overflow-x: auto; gap: 20px; padding-bottom: 10px; scrollbar-width: none; -ms-overflow-style: none;">
-                <div class="recommend-item" th:each="sim : ${similarMovies}">
-                    <a th:href="@{'/movies/' + ${sim.id}}">
-                        <img th:src="${sim.poster != null ? 'https://image.tmdb.org/t/p/w500' + sim.poster : '/images/default.jpg'}"
-                             alt="포스터" class="recommend-poster" />
-                    </a>
-                    <p class="recommend-title" th:text="${sim.title}">영화 제목</p>
+        <div class="genre-recommend-container">
+            <h3 class="recommend-title">장르가 비슷한 작품:</h3>
+            <div class="slider-wrapper">
+                <button class="slider-button left" onclick="scrollToLeft(this)">&#10094;</button>
+                <div class="recommend-list"
+                     style="display: flex; overflow-x: auto; gap: 20px; padding-bottom: 10px; scrollbar-width: none; -ms-overflow-style: none;">
+                    <div class="recommend-item" th:each="sim : ${similarMovies}">
+                        <a th:href="@{'/movies/' + ${sim.id}}">
+                            <img th:src="${sim.poster != null ? 'https://image.tmdb.org/t/p/w500' + sim.poster : '/images/default.jpg'}"
+                                 alt="포스터" class="recommend-poster"/>
+                        </a>
+                        <p class="recommend-title" th:text="${sim.title}">영화 제목</p>
+                    </div>
                 </div>
+                <button class="slider-button right" onclick="scrollToRight(this)">&#10095;</button>
             </div>
-            <button class="slider-button right" onclick="scrollToRight(this)">&#10095;</button>
         </div>
     </div>
 </div>
-
 <script>
     function showLoginBanner() {
         document.getElementById("login-banner").style.display = "flex";
@@ -436,16 +450,18 @@
     function closeLoginBanner() {
         document.getElementById("login-banner").style.display = "none";
     }
+
     function scrollToLeft(button) {
         const list = button.parentElement.querySelector(".recommend-list");
-        list.scrollBy({ left: -300, behavior: 'smooth' });
+        list.scrollBy({left: -300, behavior: 'smooth'});
+        button.blur();
     }
 
     function scrollToRight(button) {
         const list = button.parentElement.querySelector(".recommend-list");
-        list.scrollBy({ left: 300, behavior: 'smooth' });
+        list.scrollBy({left: 300, behavior: 'smooth'});
+        button.blur();
     }
-
 
     document.addEventListener("DOMContentLoaded", () => {
         document.querySelectorAll(".stars").forEach(star => {
@@ -478,7 +494,6 @@
         document.getElementById("submitTag").onclick = showLoginBanner;
         document.getElementById("tagInput").onclick = showLoginBanner;
     });
-
     document.addEventListener('keydown', function (event) {
         if (event.key === "Escape") closeLoginBanner();
     });
@@ -488,6 +503,6 @@
         if (event.target === modal) closeLoginBanner();
     });
 </script>
-    <th:block th:replace="fragments :: frg_footer"></th:block>
+<th:block th:replace="fragments :: frg_footer"></th:block>
 </body>
 </html>

--- a/backend/src/main/resources/templates/movie/guest-details.html
+++ b/backend/src/main/resources/templates/movie/guest-details.html
@@ -322,9 +322,9 @@
     <div class="login-modal-content">
         <span class="close" onclick="closeLoginBanner()">&times;</span>
         <h2>SmartMovie</h2>
-        <p>회원가입 또는 로그인이 필요한 기능입니다.<br>SmartMovie를 더 편리하게 이용해보세요.</p>
-        <button onclick="location.href='/login'">로그인</button>
-        <button onclick="location.href='/user/signup'">회원가입</button>
+        <p>This feature requires registration or login.<br>Use SmartMovie more conveniently.</p>
+        <button onclick="location.href='/login'">login</button>
+        <button onclick="location.href='/user/signup'">join member</button>
     </div>
 </div>
 <div class="overlay">
@@ -335,28 +335,27 @@
             <div class="graph">
                 <div th:each="bar : ${ratingBars}" class="bar-group">
                     <div class="bar-vertical" th:style="'height:' + (${bar.percent} * 10) + 'px'"></div>
-                    <div class="bar-label" th:text="${bar.score} + '점'"></div>
+                    <div class="bar-label" th:text="${bar.score} + 'pointer'"></div>
                 </div>
             </div>
         </div>
         <div class="info-section">
             <div class="movie-title" th:text="${movie.title}">영화 제목</div>
             <div class="info-text">
-                <strong>장르:</strong>
+                <strong>Genre :</strong>
                 <span th:each="genre : ${genres}" th:text="${genre.name} + ' '"></span>
             </div>
             <div class="info-text">
-                <span th:text="'개봉일: ' + (${movie.releaseDate} != null ? ${#temporals.format(movie.releaseDate, 'yyyy-MM-dd')} : '정보없음')"></span>
-                |
-                <span th:text="'국가: ' + (${movie.country} != null ? ${movie.country} : '정보없음')"></span> |
-                <span th:text="'관람등급: ' + (${movie.certification} != null ? ${movie.certification} : '정보없음')"></span> |
-                <span th:text="'공개 여부: ' + (${movie.isReleased} ? '공개됨' : '미공개')"></span>
+                <span th:text="'Release Date : ' + (${movie.releaseDate} != null ? ${#temporals.format(movie.releaseDate, 'yyyy-MM-dd')} : 'No information')"></span> |
+                <span th:text="'Country : ' + (${movie.country} != null ? ${movie.country} : 'No information')"></span> |
+                <span th:text="'Certification : ' + (${movie.certification} != null ? ${movie.certification} : 'No information')"></span> |
+                <span th:text="'undisclosed : ' + (${movie.isReleased} ? 'release' : 'undisclosed')"></span>
             </div>
 
             <div class="section-divider"></div>
             <div class="info-text">
-                <strong>줄거리 : </strong>
-                <span th:text="${movie.overview != null ? movie.overview : '정보없음'}"></span>
+                <strong>OverView : </strong>
+                <span th:text="${movie.overview != null ? movie.overview : 'No information'}"></span>
             </div>
 
             <div class="section-divider"></div>
@@ -365,19 +364,19 @@
                 <div class="rating-flex">
                     <!-- 왼쪽: 평가하기 -->
                     <div class="rating-left">
-                        <strong>평가하기:</strong>
+                        <strong>Leave a rating : </strong>
                         <span th:each="i : ${#numbers.sequence(1,5)}">
                         <i class="fa-regular fa-star stars" th:attr="data-score=${i}"></i></span>
                     </div>
                     <!-- 가운데: 평균 별점 -->
                     <div class="rating-center">
                         <strong th:text="${#numbers.formatDecimal(averageScore != null ? averageScore : 0.0, 1, 1)}">0.0</strong>
-                        <div style="font-size: 14px; color: #ccc;">평균 별점</div>
+                        <div style="font-size: 14px; color: #ccc;">Average Star</div>
                     </div>
                     <!-- 오른쪽: 아이콘 버튼 -->
                     <div class="rating-right">
-                        <button class="icon-button"><i class="fa-solid fa-bookmark"></i> 보고싶어요</button>
-                        <button class="icon-button"><i class="fa-solid fa-eye-slash"></i> 관심없어요</button>
+                        <button class="icon-button"><i class="fa-solid fa-bookmark"></i> Interest</button>
+                        <button class="icon-button"><i class="fa-solid fa-eye-slash"></i> UnInterest</button>
                     </div>
                 </div>
             </div>
@@ -385,9 +384,9 @@
             <div class="section-divider"></div>
 
             <div class="tag-selection">
-                <label for="tagInput"><strong>태그 남기기:</strong></label>
-                <input type="text" id="tagInput" class="browser-default" placeholder="태그를 입력하세요..." autocomplete="off"/>
-                <button id="submitTag">태그 남기기</button>
+                <label for="tagInput"><strong>Leave a tag :</strong></label>
+                <input type="text" id="tagInput" class="browser-default" placeholder="Please enter tags..." autocomplete="off"/>
+                <button id="submitTag">Leave a tag</button>
             </div>
 
             <div class="section-divider"></div>
@@ -404,7 +403,7 @@
             <div class="cast-section">
                 <!-- 감독 -->
                 <div>
-                    <strong>감독:</strong>
+                    <strong>Director :</strong>
                     <span th:if="${#lists.isEmpty(directors)}">정보없음</span>
                     <span th:each="d, stat : ${directors}" th:unless="${#lists.isEmpty(directors)}"
                           th:utext="${d.name} + (!${stat.last} ? ' | ' : '')"></span>
@@ -412,7 +411,7 @@
 
                 <!-- 출연 -->
                 <div>
-                    <strong>출연:</strong>
+                    <strong>Casting :</strong>
                     <span th:if="${#lists.isEmpty(actors)}">정보없음</span>
                     <span th:each="a, stat : ${actors}" th:unless="${#lists.isEmpty(actors)}"
                           th:utext="${a.name} + (!${stat.last} ? ' | ' : '')"></span>
@@ -423,7 +422,7 @@
     <div class="section-divider"></div>
     <div style="max-width: 1200px; margin: 0 auto; padding: 0 30px;">
         <div class="genre-recommend-container">
-            <h3 class="recommend-title">장르가 비슷한 작품:</h3>
+            <h3 class="recommend-title">Recommendations of similar genres :</h3>
             <div class="slider-wrapper">
                 <button class="slider-button left" onclick="scrollToLeft(this)">&#10094;</button>
                 <div class="recommend-list"

--- a/backend/src/main/resources/templates/movie/guest-details.html
+++ b/backend/src/main/resources/templates/movie/guest-details.html
@@ -193,7 +193,6 @@
             font-size: 28px;
             color: #f15b5b;
         }
-
         .tag-selection {
             display: flex;
             align-items: center;

--- a/backend/src/main/resources/templates/movie/member-details.html
+++ b/backend/src/main/resources/templates/movie/member-details.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
 <head>
     <title th:text="${movie.title}">영화 상세 페이지</title>
+    <th:block th:replace="fragments :: frg_static"></th:block>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <style>
         body {
@@ -77,69 +78,8 @@
             min-height: 100vh;
         }
 
-        nav {
-            background-color: #1e1e1e;
-            padding: 15px 30px;
-
-            display: flex;
-            justify-content: center;
-        }
-
-        .nav-content {
-            width: 100%;
-            max-width: 1200px;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-
-        .nav-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: white;
-            text-decoration: none;
-        }
-
-        .nav-menu a {
-            color: white;
-            text-decoration: none;
-            margin-left: 20px;
-            font-size: 16px;
-        }
-
-        .nav-menu a.logout {
-            color: red;
-        }
-
-        .nav-logo {
-            font-size: 24px;
-            font-weight: bold;
-            color: white;
-            text-decoration: none;
-        }
-
-        .nav-menu a {
-            color: white;
-            text-decoration: none;
-            margin-left: 20px;
-            font-size: 16px;
-        }
-
-        .nav-menu a.logout {
-            color: red;
-        }
-
-        nav a {
-            color: white;
-            text-decoration: none;
-            margin-left: 20px;
-        }
-
-        nav a:last-child {
-            color: red;
-        }
-
         .main-section {
+            width: 100%;
             max-width: 1200px;
             margin: 0 auto;
             padding: 30px;
@@ -151,7 +91,6 @@
             width: 300px;
             border-radius: 10px;
         }
-
         .graph {
             width: 300px;
             display: flex;
@@ -256,11 +195,20 @@
         }
 
         .tag-selection {
-            margin-top: 30px;
-            margin-bottom: 10px;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            position: relative;
         }
 
-        #tagInput {
+        .tag-selection label {
+            font-size: 16px;
+            font-weight: bold;
+            color: white;
+            white-space: nowrap;
+        }
+
+        input#tagInput[type="text"] {
             border: none;
             outline: none;
             box-shadow: none;
@@ -268,17 +216,29 @@
             color: black;
             padding: 6px 10px;
             border-radius: 4px;
+            width: 180px !important;
+            flex-shrink: 0;
         }
 
+        #submitTag {
+            white-space: nowrap;
+            height: 30px;
+            padding: 0 5px;
+            font-size: 14px;
+        }
         #suggestions {
-            background: white;
-            border: 1px solid #ccc;
             position: absolute;
-            z-index: 1000;
-            max-height: 150px;
-            overflow-y: auto;
-            width: 200px;
+            top: calc(100% + 4px);
+            left: 0;
+            background-color: white;
             color: black;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            width: 180px;
+            max-height: 200px;
+            overflow-y: auto;
+            z-index: 999;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
         }
 
         #suggestions:empty {
@@ -324,25 +284,17 @@
         .cast-section div {
             margin-bottom: 10px;
         }
+        h3, h4 {
+            font-size: 18px;
+            font-weight: bold;
+            margin: 10px 0;
+            color: white;
+        }
     </style>
 </head>
 <body th:attr="data-movie-id=${movie.id}, data-user-id=${userId}">
+<th:block th:replace="fragments :: frg_header"></th:block>
 <div class="overlay">
-
-    <nav>
-        <div class="nav-content">
-            <a href="/" class="nav-logo">
-                <i class="fa-solid fa-clapperboard" style="color: #a58efc;"></i> SmartMovie
-            </a>
-            <div class="nav-menu">
-                <a href="/">Home</a>
-                <a href="/search">Search</a>
-                <a href="/mypage"><i class="fa-solid fa-user"></i> My Page</a>
-                <a href="/logout" class="logout">Logout</a>
-            </div>
-        </div>
-    </nav>
-
 
     <div class="main-section">
         <div class="poster">
@@ -411,18 +363,18 @@
 
             <div class="tag-selection">
                 <label for="tagInput"><strong>태그 남기기:</strong></label>
-                <input type="text" id="tagInput" placeholder="태그를 입력하세요..." autocomplete="off"/>
+                <input type="text" id="tagInput" class="browser-default" placeholder="태그를 입력하세요..." autocomplete="off"/>
                 <div id="suggestions"></div>
                 <button id="submitTag" disabled>태그 남기기</button>
 
-                <div class="section-divider"></div>
+            </div>
+            <div class="section-divider"></div>
 
-                <div class="my-tags">
-                    <h4>내가 남긴 태그</h4>
-                    <ul id="my-tags">
-                        <li th:each="tag : ${userTags}" th:text="'# ' + ${tag.name}"></li>
-                    </ul>
-                </div>
+            <div class="my-tags">
+                <h4>내가 남긴 태그</h4>
+                <ul id="my-tags">
+                    <li th:each="tag : ${userTags}" th:text="'# ' + ${tag.name}"></li>
+                </ul>
             </div>
 
             <div class="section-divider"></div>
@@ -463,330 +415,333 @@
                 <button class="slider-button right" onclick="scrollToRight(this)">&#10095;</button>
             </div>
         </div>
-        <div>
-        </div>
-        <script>
-            async function loadMyTags() {
-                const response = await fetch(`/movies/${movieId}/tags/user`);
-                if (!response.ok) return;
+    </div>
+</div>
+<script>
+    async function loadMyTags() {
+        const response = await fetch(`/movies/${movieId}/tags/user`);
+        if (!response.ok) return;
 
-                const tags = await response.json();
-                myTags.innerHTML = '';
-                tags.forEach(tag => {
-                    myTags.appendChild(createTagListItem(tag));
-                });
-            }
+        const tags = await response.json();
+        myTags.innerHTML = '';
+        tags.forEach(tag => {
+            myTags.appendChild(createTagListItem(tag));
+        });
+    }
 
-            async function loadTopTags() {
-                const response = await fetch(`/movies/${movieId}/tags/top6?movieId=${movieId}`);
-                const tags = await response.json();
-                const list = document.querySelector(".top-tags ul");
-                list.innerHTML = '';
-                tags.forEach(tag => {
-                    const li = document.createElement("li");
-                    li.textContent = `# ${tag.name}`;
-                    list.appendChild(li);
-                });
-            }
+    async function loadTopTags() {
+        const response = await fetch(`/movies/${movieId}/tags/top6?movieId=${movieId}`);
+        const tags = await response.json();
+        const list = document.querySelector(".top-tags ul");
+        list.innerHTML = '';
+        tags.forEach(tag => {
+            const li = document.createElement("li");
+            li.textContent = `# ${tag.name}`;
+            list.appendChild(li);
+        });
+    }
 
-            async function loadAverageScore() {
-                const res = await fetch(`/movies/${movieId}/ratings/average`);
-                if (!res.ok) return;
-                const avg = await res.json();
+    async function loadAverageScore() {
+        const res = await fetch(`/movies/${movieId}/ratings/average`);
+        if (!res.ok) return;
+        const avg = await res.json();
 
-                document.querySelector(".rating-center strong").textContent = avg.toFixed(1);
-            }
+        document.querySelector(".rating-center strong").textContent = avg.toFixed(1);
+    }
 
-            async function loadRatingBars() {
-                const res = await fetch(`/movies/${movieId}/ratings/bars`);
-                if (!res.ok) return;
+    async function loadRatingBars() {
+        const res = await fetch(`/movies/${movieId}/ratings/bars`);
+        if (!res.ok) return;
 
-                const bars = await res.json();
-                const graph = document.querySelector(".graph");
-                graph.innerHTML = "";  // 기존 그래프 초기화
+        const bars = await res.json();
+        const graph = document.querySelector(".graph");
+        graph.innerHTML = "";  // 기존 그래프 초기화
 
-                const maxHeight = 100;
+        const maxHeight = 100;
 
-                bars.forEach(bar => {
-                    const group = document.createElement("div");
-                    group.className = "bar-group";
+        bars.forEach(bar => {
+            const group = document.createElement("div");
+            group.className = "bar-group";
 
-                    const barDiv = document.createElement("div");
-                    barDiv.className = "bar-vertical";
-                    barDiv.style.height = (bar.percent * 10) + "px";
+            const barDiv = document.createElement("div");
+            barDiv.className = "bar-vertical";
+            barDiv.style.height = (bar.percent * 10) + "px";
 
-                    const label = document.createElement("div");
-                    label.className = "bar-label";
-                    label.textContent = bar.score + "점";
+            const label = document.createElement("div");
+            label.className = "bar-label";
+            label.textContent = bar.score + "점";
 
-                    group.appendChild(barDiv);
-                    group.appendChild(label);
-                    graph.appendChild(group);
-                });
-            }
+            group.appendChild(barDiv);
+            group.appendChild(label);
+            graph.appendChild(group);
+        });
+    }
 
-            function rateMovie(movieId, score) {
-                fetch(`/movies/${movieId}/ratings`, {
-                    method: 'POST',
-                    headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify({movieId, score})
-                }).then(res => {
-                    if (res.ok) {
-                        document.querySelectorAll(".stars").forEach(s => {
-                            s.classList.remove("selected", "fa-solid");
-                            s.classList.add("fa-regular");
-                            const sScore = parseInt(s.dataset.score);
-                            if (sScore <= score) {
-                                s.classList.add("selected", "fa-solid");
-                                s.classList.remove("fa-regular");
-                            }
-                        });
-                        alert("평점이 성공적으로 등록되었습니다.");
-                        setTimeout(() => {
-                            loadAverageScore();
-                            loadRatingBars();
-                        }, 100);
-                        //loadMyTags();
-                        //loadTopTags();
-                    } else {
-                        alert("오류 발생!");
+    function rateMovie(movieId, score) {
+        fetch(`/movies/${movieId}/ratings`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({movieId, score})
+        }).then(res => {
+            if (res.ok) {
+                document.querySelectorAll(".stars").forEach(s => {
+                    s.classList.remove("selected", "fa-solid");
+                    s.classList.add("fa-regular");
+                    const sScore = parseInt(s.dataset.score);
+                    if (sScore <= score) {
+                        s.classList.add("selected", "fa-solid");
+                        s.classList.remove("fa-regular");
                     }
                 });
+                alert("평점이 성공적으로 등록되었습니다.");
+                setTimeout(() => {
+                    loadAverageScore();
+                    loadRatingBars();
+                }, 100);
+                //loadMyTags();
+                //loadTopTags();
+            } else {
+                alert("오류 발생!");
             }
-            function cancelRating() {
-                fetch(`/movies/${movieId}/ratings`, { method: 'DELETE' })
-                    .then(res => {
-                        if (res.ok) {
-                            alert("평가가 취소되었습니다.");
-                            // 별점 UI 초기화
-                            document.querySelectorAll(".stars").forEach(s => {
-                                s.classList.remove("selected", "fa-solid");
-                                s.classList.add("fa-regular");
-                            });
-                            loadAverageScore();
-                            loadRatingBars();
-                        } else {
-                            alert("평가 취소 실패");
-                        }
+        });
+    }
+
+    function cancelRating() {
+        fetch(`/movies/${movieId}/ratings`, {method: 'DELETE'})
+            .then(res => {
+                if (res.ok) {
+                    alert("평가가 취소되었습니다.");
+                    // 별점 UI 초기화
+                    document.querySelectorAll(".stars").forEach(s => {
+                        s.classList.remove("selected", "fa-solid");
+                        s.classList.add("fa-regular");
                     });
-            }
-            function setInterest(status) {
-                const movieId = document.body.getAttribute("data-movie-id");
-
-                const bookmarkIcon = document.querySelector("i.fa-bookmark");
-                const eyeSlashIcon = document.querySelector("i.fa-eye-slash");
-
-                const isBookmarkActive = bookmarkIcon.classList.contains("active");
-                const isEyeSlashActive = eyeSlashIcon.classList.contains("active");
-
-                const isSameClicked =
-                    (status === "WATCH_LATER" && isBookmarkActive) ||
-                    (status === "NOT_INTERESTED" && isEyeSlashActive);
-
-                if (isSameClicked) {
-                    // 👇 같은 상태 다시 클릭 → 취소 요청 (DELETE)
-                    fetch(`/movies/${movieId}/interest`, {
-                        method: 'DELETE'
-                    }).then(res => {
-                        if (res.ok) {
-                            // 아이콘 초기화
-                            bookmarkIcon.classList.remove("fa-solid", "active");
-                            bookmarkIcon.classList.add("fa-regular");
-
-                            eyeSlashIcon.classList.remove("fa-solid", "active");
-                            eyeSlashIcon.classList.add("fa-regular");
-
-                            alert("관심 상태가 취소되었습니다.");
-                        } else {
-                            alert("관심 상태 취소에 실패했습니다.");
-                        }
-                    });
+                    loadAverageScore();
+                    loadRatingBars();
                 } else {
-                    // 👇 새로운 관심 상태 등록
-                    fetch(`/movies/${movieId}/interest?status=${status}`, {
-                        method: 'POST'
-                    }).then(res => {
-                        if (res.ok) {
-                            // 아이콘 초기화
-                            bookmarkIcon.classList.remove("fa-solid", "active");
-                            bookmarkIcon.classList.add("fa-regular");
+                    alert("평가 취소 실패");
+                }
+            });
+    }
 
-                            eyeSlashIcon.classList.remove("fa-solid", "active");
-                            eyeSlashIcon.classList.add("fa-regular");
+    function setInterest(status) {
+        const movieId = document.body.getAttribute("data-movie-id");
 
-                            // 선택한 아이콘 활성화
-                            const selectedIcon = status === "WATCH_LATER" ? bookmarkIcon : eyeSlashIcon;
-                            selectedIcon.classList.add("fa-solid", "active");
-                            selectedIcon.classList.remove("fa-regular");
+        const bookmarkIcon = document.querySelector("i.fa-bookmark");
+        const eyeSlashIcon = document.querySelector("i.fa-eye-slash");
 
-                            alert(
-                                status === "WATCH_LATER"
-                                    ? "보고싶어요로 등록되었습니다."
-                                    : "관심없어요로 등록되었습니다."
-                            );
-                        } else {
-                            alert("관심 상태 등록에 실패했습니다.");
-                        }
+        const isBookmarkActive = bookmarkIcon.classList.contains("active");
+        const isEyeSlashActive = eyeSlashIcon.classList.contains("active");
+
+        const isSameClicked =
+            (status === "WATCH_LATER" && isBookmarkActive) ||
+            (status === "NOT_INTERESTED" && isEyeSlashActive);
+
+        if (isSameClicked) {
+            // 👇 같은 상태 다시 클릭 → 취소 요청 (DELETE)
+            fetch(`/movies/${movieId}/interest`, {
+                method: 'DELETE'
+            }).then(res => {
+                if (res.ok) {
+                    // 아이콘 초기화
+                    bookmarkIcon.classList.remove("fa-solid", "active");
+                    bookmarkIcon.classList.add("fa-regular");
+
+                    eyeSlashIcon.classList.remove("fa-solid", "active");
+                    eyeSlashIcon.classList.add("fa-regular");
+
+                    alert("관심 상태가 취소되었습니다.");
+                } else {
+                    alert("관심 상태 취소에 실패했습니다.");
+                }
+            });
+        } else {
+            // 👇 새로운 관심 상태 등록
+            fetch(`/movies/${movieId}/interest?status=${status}`, {
+                method: 'POST'
+            }).then(res => {
+                if (res.ok) {
+                    // 아이콘 초기화
+                    bookmarkIcon.classList.remove("fa-solid", "active");
+                    bookmarkIcon.classList.add("fa-regular");
+
+                    eyeSlashIcon.classList.remove("fa-solid", "active");
+                    eyeSlashIcon.classList.add("fa-regular");
+
+                    // 선택한 아이콘 활성화
+                    const selectedIcon = status === "WATCH_LATER" ? bookmarkIcon : eyeSlashIcon;
+                    selectedIcon.classList.add("fa-solid", "active");
+                    selectedIcon.classList.remove("fa-regular");
+
+                    alert(
+                        status === "WATCH_LATER"
+                            ? "보고싶어요로 등록되었습니다."
+                            : "관심없어요로 등록되었습니다."
+                    );
+                } else {
+                    alert("관심 상태 등록에 실패했습니다.");
+                }
+            });
+        }
+    }
+
+
+    function createTagListItem(tag) {
+        const li = document.createElement("li");
+        li.textContent = `# ${tag} `;
+
+        const btn = document.createElement("button");
+        btn.textContent = "x";
+        btn.style.marginLeft = "5px";
+        btn.style.background = "none";
+        btn.style.border = "none";
+        btn.style.color = "white";
+        btn.style.cursor = "pointer";
+        btn.onclick = () => deleteTag(tag);
+
+        li.appendChild(btn);
+        return li;
+    }
+
+    function deleteTag(tagName) {
+        if (!confirm(`'${tagName}' 태그를 삭제할까요?`)) return;
+
+        fetch(`/movies/${movieId}/tags/delete?tagName=${encodeURIComponent(tagName)}`, {
+            method: 'DELETE'
+        }).then(res => {
+            if (res.ok) {
+                alert("삭제되었습니다.");
+                loadMyTags();   // 내 태그 다시 불러오기
+                loadTopTags();  // Top 태그도 다시 반영
+            } else {
+                alert("삭제에 실패했습니다.");
+            }
+        });
+    }
+
+    function scrollToLeft(button) {
+        const list = button.parentElement.querySelector(".recommend-list");
+        list.scrollBy({left: -300, behavior: 'smooth'});
+    }
+
+    function scrollToRight(button) {
+        const list = button.parentElement.querySelector(".recommend-list");
+        list.scrollBy({left: 300, behavior: 'smooth'});
+    }
+
+
+    const tagInput = document.getElementById("tagInput");
+    const suggestions = document.getElementById("suggestions");
+    const submitBtn = document.getElementById("submitTag");
+    const myTags = document.getElementById("my-tags");
+    const movieId = document.body.getAttribute("data-movie-id");
+    const userId = document.body.getAttribute("data-user-id");
+
+    let selectedTag = null;
+
+    tagInput.addEventListener("input", async () => {
+        const keyword = tagInput.value.trim();
+        suggestions.innerHTML = '';
+        selectedTag = null;
+        submitBtn.disabled = true;
+
+        if (keyword.length > 0) {
+            const res = await fetch(`/movies/${movieId}/tags/search?keyword=${keyword}`);
+            if (!res.ok) return;
+            const tags = await res.json();
+
+            if (tags.length > 0) {
+                suggestions.style.display = 'block';
+                tags.forEach(tag => {
+                    const div = document.createElement("div");
+                    div.textContent = tag.name;
+                    div.style.padding = "5px";
+                    div.style.cursor = "pointer";
+                    div.addEventListener("click", () => {
+                        tagInput.value = tag.name;
+                        selectedTag = tag;
+                        suggestions.innerHTML = '';
+                        suggestions.style.display = 'none';
+                        submitBtn.disabled = false;
                     });
-                }
-            }
-
-
-            function createTagListItem(tag) {
-                const li = document.createElement("li");
-                li.textContent = `# ${tag} `;
-
-                const btn = document.createElement("button");
-                btn.textContent = "x";
-                btn.style.marginLeft = "5px";
-                btn.style.background = "none";
-                btn.style.border = "none";
-                btn.style.color = "white";
-                btn.style.cursor = "pointer";
-                btn.onclick = () => deleteTag(tag);
-
-                li.appendChild(btn);
-                return li;
-            }
-
-            function deleteTag(tagName) {
-                if (!confirm(`'${tagName}' 태그를 삭제할까요?`)) return;
-
-                fetch(`/movies/${movieId}/tags/delete?tagName=${encodeURIComponent(tagName)}`, {
-                    method: 'DELETE'
-                }).then(res => {
-                    if (res.ok) {
-                        alert("삭제되었습니다.");
-                        loadMyTags();   // 내 태그 다시 불러오기
-                        loadTopTags();  // Top 태그도 다시 반영
-                    } else {
-                        alert("삭제에 실패했습니다.");
-                    }
+                    suggestions.appendChild(div);
                 });
             }
+        }
+    });
 
-            function scrollToLeft(button) {
-                const list = button.parentElement.querySelector(".recommend-list");
-                list.scrollBy({left: -300, behavior: 'smooth'});
-            }
+    submitBtn.addEventListener("click", async () => {
+        if (!selectedTag) {
+            selectedTag = {name: tagInput.value.trim()};
+        }
 
-            function scrollToRight(button) {
-                const list = button.parentElement.querySelector(".recommend-list");
-                list.scrollBy({left: 300, behavior: 'smooth'});
-            }
+        if (!selectedTag.name) return;
+
+        const res = await fetch(`/movies/${movieId}/tags/select?tagName=${selectedTag.name}`, {
+            method: 'POST'
+        });
+
+        if (res.status === 409) {
+            const message = await res.text();
+            alert(message);
+            return
+        }
+
+        if (!res.ok) {
+            alert("태그 등록에 실패했습니다.");
+            return;
+        }
+
+        if (![...myTags.children].some(li => li.textContent.trim().startsWith(`# ${selectedTag.name}`))) {
+            const tagElement = createTagListItem(selectedTag.name);
+            myTags.appendChild(tagElement);
+        }
 
 
-            const tagInput = document.getElementById("tagInput");
-            const suggestions = document.getElementById("suggestions");
-            const submitBtn = document.getElementById("submitTag");
-            const myTags = document.getElementById("my-tags");
-            const movieId = document.body.getAttribute("data-movie-id");
-            const userId = document.body.getAttribute("data-user-id");
+        tagInput.value = '';
+        submitBtn.disabled = true;
 
-            let selectedTag = null;
+        await loadTopTags();
+    });
 
-            tagInput.addEventListener("input", async () => {
-                const keyword = tagInput.value.trim();
-                suggestions.innerHTML = '';
-                selectedTag = null;
-                submitBtn.disabled = true;
+    document.addEventListener('click', function (event) {
+        if (!tagInput.contains(event.target) && !suggestions.contains(event.target)) {
+            suggestions.style.display = 'none';
+        }
+    });
 
-                if (keyword.length > 0) {
-                    const res = await fetch(`/movies/${movieId}/tags/search?keyword=${keyword}`);
-                    if (!res.ok) return;
-                    const tags = await res.json();
+    tagInput.addEventListener('focus', function () {
+        if (suggestions.children.length > 0) {
+            suggestions.style.display = 'block';
+        }
+    });
 
-                    if (tags.length > 0) {
-                        suggestions.style.display = 'block';
-                        tags.forEach(tag => {
-                            const div = document.createElement("div");
-                            div.textContent = tag.name;
-                            div.style.padding = "5px";
-                            div.style.cursor = "pointer";
-                            div.addEventListener("click", () => {
-                                tagInput.value = tag.name;
-                                selectedTag = tag;
-                                suggestions.innerHTML = '';
-                                suggestions.style.display = 'none';
-                                submitBtn.disabled = false;
-                            });
-                            suggestions.appendChild(div);
-                        });
-                    }
+    document.querySelectorAll(".stars").forEach(star => {
+        star.addEventListener("mouseenter", () => {
+            const score = parseInt(star.dataset.score);
+            document.querySelectorAll(".stars").forEach(s => {
+                if (parseInt(s.dataset.score) <= score) {
+                    s.classList.add("hovered", "fa-solid");
+                    s.classList.remove("fa-regular");
                 }
             });
+        });
 
-            submitBtn.addEventListener("click", async () => {
-                if (!selectedTag) {
-                    selectedTag = {name: tagInput.value.trim()};
-                }
-
-                if (!selectedTag.name) return;
-
-                const res = await fetch(`/movies/${movieId}/tags/select?tagName=${selectedTag.name}`, {
-                    method: 'POST'
-                });
-
-                if (res.status === 409) {
-                    const message = await res.text();
-                    alert(message);
-                    return
-                }
-
-                if (!res.ok) {
-                    alert("태그 등록에 실패했습니다.");
-                    return;
-                }
-
-                if (![...myTags.children].some(li => li.textContent.trim().startsWith(`# ${selectedTag.name}`))) {
-                    const tagElement = createTagListItem(selectedTag.name);
-                    myTags.appendChild(tagElement);
-                }
-
-
-                tagInput.value = '';
-                submitBtn.disabled = true;
-
-                await loadTopTags();
-            });
-
-            document.addEventListener('click', function (event) {
-                if (!tagInput.contains(event.target) && !suggestions.contains(event.target)) {
-                    suggestions.style.display = 'none';
+        star.addEventListener("mouseleave", () => {
+            document.querySelectorAll(".stars").forEach(s => {
+                s.classList.remove("hovered");
+                if (!s.classList.contains("selected")) {
+                    s.classList.remove("fa-solid");
+                    s.classList.add("fa-regular");
                 }
             });
+        });
+    });
 
-            tagInput.addEventListener('focus', function () {
-                if (suggestions.children.length > 0) {
-                    suggestions.style.display = 'block';
-                }
-            });
-
-            document.querySelectorAll(".stars").forEach(star => {
-                star.addEventListener("mouseenter", () => {
-                    const score = parseInt(star.dataset.score);
-                    document.querySelectorAll(".stars").forEach(s => {
-                        if (parseInt(s.dataset.score) <= score) {
-                            s.classList.add("hovered", "fa-solid");
-                            s.classList.remove("fa-regular");
-                        }
-                    });
-                });
-
-                star.addEventListener("mouseleave", () => {
-                    document.querySelectorAll(".stars").forEach(s => {
-                        s.classList.remove("hovered");
-                        if (!s.classList.contains("selected")) {
-                            s.classList.remove("fa-solid");
-                            s.classList.add("fa-regular");
-                        }
-                    });
-                });
-            });
-
-            // 초기 로딩 시 사용자 태그/Top 태그 불러오기
-            loadMyTags();
-            loadTopTags();
-        </script>
+    // 초기 로딩 시 사용자 태그/Top 태그 불러오기
+    loadMyTags();
+    loadTopTags();
+</script>
+<th:block th:replace="fragments :: frg_footer"></th:block>
 </body>
 </html>

--- a/backend/src/main/resources/templates/movie/member-details.html
+++ b/backend/src/main/resources/templates/movie/member-details.html
@@ -167,6 +167,19 @@
             text-align: center;
         }
 
+        .icon-button.cancel-btn {
+            background-color: #f15b5b;
+            color: white;
+            border-radius: 4px;
+            padding: 4px 10px;
+            font-size: 14px;
+            transition: background-color 0.2s ease;
+        }
+
+        .icon-button.cancel-btn:hover {
+            background-color: #d84444;
+        }
+
         .stars {
             font-size: 24px;
             color: #ccc;
@@ -306,7 +319,21 @@
         .slider-button:focus {
             background-color: #27c29c;
         }
+        .rating-inline {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            white-space: nowrap;
+        }
+        .rating-label {
+            font-size: 16px;
+            font-weight: bold;
+        }
 
+        .rating-stars {
+            display: flex;
+            gap: 8px;
+        }
     </style>
 </head>
 <body th:attr="data-movie-id=${movie.id}, data-user-id=${userId}">
@@ -348,16 +375,17 @@
 
             <div class="rating-wrapper">
                 <div class="rating-flex">
-                    <div class="rating-left">
-                        <strong>평가하기:</strong>
-                        <span th:each="i : ${#numbers.sequence(1,5)}">
-                            <i class="fa-star stars"
-                               th:classappend="${userRating >= i} ? 'fa-solid selected' : 'fa-regular'"
-                               th:attr="data-score=${i}, onclick=|rateMovie(${movie.id},${i})|">
+                    <div class="rating-left rating-inline">
+                        <strong class="rating-label">평가 남기기:</strong>
+                        <span class="rating-stars" th:each="i : ${#numbers.sequence(1,5)}">
+                            <i class="fa-star stars" th:classappend="${userRating >= i} ? 'fa-solid selected' : 'fa-regular'"
+                                th:attr="data-score=${i}, onclick=|rateMovie(${movie.id},${i})|">
                             </i>
                         </span>
-                        <button class="icon-button" onclick="cancelRating()">평가 취소</button>
+                        <button class="icon-button cancel-btn" onclick="cancelRating()">평가 취소</button>
                     </div>
+
+
                     <div class="rating-center">
                         <strong th:text="${#numbers.formatDecimal(averageScore != null ? averageScore : 0.0, 1, 1)}">0.0</strong>
                         <div style="font-size: 14px; color: #ccc;">평균 별점</div>
@@ -523,11 +551,17 @@
     }
 
     function cancelRating() {
+        const ratedStars = document.querySelectorAll(".stars.selected");
+
+        if (ratedStars.length === 0) {
+            alert("평가가 없습니다.");
+            return;
+        }
+
         fetch(`/movies/${movieId}/ratings`, {method: 'DELETE'})
             .then(res => {
                 if (res.ok) {
                     alert("평가가 취소되었습니다.");
-                    // 별점 UI 초기화
                     document.querySelectorAll(".stars").forEach(s => {
                         s.classList.remove("selected", "fa-solid");
                         s.classList.add("fa-regular");
@@ -539,6 +573,7 @@
                 }
             });
     }
+
 
     function setInterest(status) {
         const movieId = document.body.getAttribute("data-movie-id");

--- a/backend/src/main/resources/templates/movie/member-details.html
+++ b/backend/src/main/resources/templates/movie/member-details.html
@@ -11,6 +11,67 @@
             color: #ffffff;
         }
 
+        .genre-recommend-container {
+            padding: 20px 0;
+        }
+
+        .slider-wrapper {
+            position: relative;
+            display: flex;
+            align-items: center;
+        }
+
+        .recommend-list {
+            display: flex;
+            overflow-x: auto;
+            gap: 20px;
+            scroll-behavior: smooth;
+            padding: 10px 0;
+            margin: 0 40px;
+        }
+
+        .recommend-list::-webkit-scrollbar {
+            display: none;
+        }
+
+        .recommend-item {
+            width: 120px;
+            flex-shrink: 0;
+            text-align: center;
+        }
+
+        .recommend-poster {
+            width: 100%;
+            border-radius: 8px;
+        }
+
+        .slider-button {
+            position: absolute;
+            z-index: 10;
+            width: 36px;
+            height: 36px;
+            border-radius: 50%;
+            border: none;
+            background-color: rgba(0, 0, 0, 0.5);
+            color: white;
+            font-size: 18px;
+            cursor: pointer;
+            transition: background-color 0.3s ease;
+        }
+
+        .slider-button.left {
+            left: 0;
+        }
+
+        .slider-button.right {
+            right: 0;
+        }
+
+        .slider-button:hover {
+            background-color: #27c29c;
+        }
+
+
         .overlay {
             background-color: rgba(0, 0, 0, 0.85);
             min-height: 100vh;
@@ -49,6 +110,7 @@
         .nav-menu a.logout {
             color: red;
         }
+
         .nav-logo {
             font-size: 24px;
             font-weight: bold;
@@ -284,7 +346,8 @@
 
     <div class="main-section">
         <div class="poster">
-            <img th:src="${movie.poster != null ? 'https://image.tmdb.org/t/p/w500' + movie.poster : '/images/default.jpg'}" alt="포스터">
+            <img th:src="${movie.poster != null ? 'https://image.tmdb.org/t/p/w500' + movie.poster : '/images/default.jpg'}"
+                 alt="포스터">
             <div class="graph">
                 <div th:each="bar : ${ratingBars}" class="bar-group">
                     <div class="bar-vertical" th:style="'height:' + (${bar.percent} * 10) + 'px'"></div>
@@ -300,7 +363,8 @@
                 <span th:each="genre : ${genres}" th:text="${genre.name} + ' '"></span>
             </div>
             <div class="info-text">
-                <span th:text="'개봉일: ' + (${movie.releaseDate} != null ? ${#temporals.format(movie.releaseDate, 'yyyy-MM-dd')} : '정보없음')"></span> |
+                <span th:text="'개봉일: ' + (${movie.releaseDate} != null ? ${#temporals.format(movie.releaseDate, 'yyyy-MM-dd')} : '정보없음')"></span>
+                |
                 <span th:text="'국가: ' + (${movie.country} != null ? ${movie.country} : '정보없음')"></span> |
                 <span th:text="'관람등급: ' + (${movie.certification} != null ? ${movie.certification} : '정보없음')"></span> |
                 <span th:text="'공개 여부: ' + (${movie.isReleased} ? '공개됨' : '미공개')"></span>
@@ -372,279 +436,314 @@
             <div class="section-divider"></div>
 
             <div class="cast-section">
-                <div><strong>감독:</strong> <span th:each="d, stat : ${directors}" th:utext="${d.name} + (!${stat.last} ? ' | ' : '')"></span></div>
-                <div><strong>출연:</strong> <span th:each="a, stat : ${actors}" th:utext="${a.name} + (!${stat.last} ? ' | ' : '')"></span></div>
+                <div><strong>감독:</strong> <span th:each="d, stat : ${directors}"
+                                                th:utext="${d.name} + (!${stat.last} ? ' | ' : '')"></span></div>
+                <div><strong>출연:</strong> <span th:each="a, stat : ${actors}"
+                                                th:utext="${a.name} + (!${stat.last} ? ' | ' : '')"></span></div>
             </div>
         </div>
     </div>
-</div>
-<script>
-    async function loadMyTags() {
-        const response = await fetch(`/movies/${movieId}/tags/user`);
-        if (!response.ok) return;
+    <div class="section-divider"></div>
+    <div style="max-width: 1200px; margin: 0 auto; padding: 0 30px;">
+        <div class="genre-recommend-container">
+            <h3 class="recommend-title">장르가 비슷한 작품:</h3>
+            <div class="slider-wrapper">
+                <button class="slider-button left" onclick="scrollToLeft(this)">&#10094;</button>
+                <div class="recommend-list"
+                     style="display: flex; overflow-x: auto; gap: 20px; padding-bottom: 10px; scrollbar-width: none; -ms-overflow-style: none;">
+                    <div class="recommend-item" th:each="sim : ${similarMovies}">
+                        <a th:href="@{'/movies/' + ${sim.id}}">
+                            <img th:src="${sim.poster != null ? 'https://image.tmdb.org/t/p/w500' + sim.poster : '/images/default.jpg'}"
+                                 alt="포스터" class="recommend-poster"/>
+                        </a>
+                        <p class="recommend-title" th:text="${sim.title}">영화 제목</p>
+                    </div>
+                </div>
+                <button class="slider-button right" onclick="scrollToRight(this)">&#10095;</button>
+            </div>
+        </div>
+        <div>
+        </div>
+        <script>
+            async function loadMyTags() {
+                const response = await fetch(`/movies/${movieId}/tags/user`);
+                if (!response.ok) return;
 
-        const tags = await response.json();
-        myTags.innerHTML = '';
-        tags.forEach(tag => {
-            myTags.appendChild(createTagListItem(tag));
-        });
-    }
+                const tags = await response.json();
+                myTags.innerHTML = '';
+                tags.forEach(tag => {
+                    myTags.appendChild(createTagListItem(tag));
+                });
+            }
 
-    async function loadTopTags() {
-        const response = await fetch(`/movies/${movieId}/tags/top6?movieId=${movieId}`);
-        const tags = await response.json();
-        const list = document.querySelector(".top-tags ul");
-        list.innerHTML = '';
-        tags.forEach(tag => {
-            const li = document.createElement("li");
-            li.textContent = `# ${tag.name}`;
-            list.appendChild(li);
-        });
-    }
-    async function loadAverageScore() {
-        const res = await fetch(`/movies/${movieId}/ratings/average`);
-        if (!res.ok) return;
-        const avg = await res.json();
+            async function loadTopTags() {
+                const response = await fetch(`/movies/${movieId}/tags/top6?movieId=${movieId}`);
+                const tags = await response.json();
+                const list = document.querySelector(".top-tags ul");
+                list.innerHTML = '';
+                tags.forEach(tag => {
+                    const li = document.createElement("li");
+                    li.textContent = `# ${tag.name}`;
+                    list.appendChild(li);
+                });
+            }
 
-        document.querySelector(".rating-center strong").textContent = avg.toFixed(1);
-    }
-    async function loadRatingBars() {
-        const res = await fetch(`/movies/${movieId}/ratings/bars`);
-        if (!res.ok) return;
+            async function loadAverageScore() {
+                const res = await fetch(`/movies/${movieId}/ratings/average`);
+                if (!res.ok) return;
+                const avg = await res.json();
 
-        const bars = await res.json();
-        const graph = document.querySelector(".graph");
-        graph.innerHTML = "";  // 기존 그래프 초기화
+                document.querySelector(".rating-center strong").textContent = avg.toFixed(1);
+            }
 
-        const maxHeight = 100;
+            async function loadRatingBars() {
+                const res = await fetch(`/movies/${movieId}/ratings/bars`);
+                if (!res.ok) return;
 
-        bars.forEach(bar => {
-            const group = document.createElement("div");
-            group.className = "bar-group";
+                const bars = await res.json();
+                const graph = document.querySelector(".graph");
+                graph.innerHTML = "";  // 기존 그래프 초기화
 
-            const barDiv = document.createElement("div");
-            barDiv.className = "bar-vertical";
-            barDiv.style.height = (bar.percent * 10) + "px";
+                const maxHeight = 100;
 
-            const label = document.createElement("div");
-            label.className = "bar-label";
-            label.textContent = bar.score + "점";
+                bars.forEach(bar => {
+                    const group = document.createElement("div");
+                    group.className = "bar-group";
 
-            group.appendChild(barDiv);
-            group.appendChild(label);
-            graph.appendChild(group);
-        });
-    }
+                    const barDiv = document.createElement("div");
+                    barDiv.className = "bar-vertical";
+                    barDiv.style.height = (bar.percent * 10) + "px";
 
-    function rateMovie(movieId, score) {
-        fetch(`/movies/${movieId}/ratings`, {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({movieId, score})
-        }).then(res => {
-            if (res.ok) {
-                document.querySelectorAll(".stars").forEach(s => {
-                    s.classList.remove("selected", "fa-solid");
-                    s.classList.add("fa-regular");
-                    const sScore = parseInt(s.dataset.score);
-                    if (sScore <= score) {
-                        s.classList.add("selected", "fa-solid");
-                        s.classList.remove("fa-regular");
+                    const label = document.createElement("div");
+                    label.className = "bar-label";
+                    label.textContent = bar.score + "점";
+
+                    group.appendChild(barDiv);
+                    group.appendChild(label);
+                    graph.appendChild(group);
+                });
+            }
+
+            function rateMovie(movieId, score) {
+                fetch(`/movies/${movieId}/ratings`, {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({movieId, score})
+                }).then(res => {
+                    if (res.ok) {
+                        document.querySelectorAll(".stars").forEach(s => {
+                            s.classList.remove("selected", "fa-solid");
+                            s.classList.add("fa-regular");
+                            const sScore = parseInt(s.dataset.score);
+                            if (sScore <= score) {
+                                s.classList.add("selected", "fa-solid");
+                                s.classList.remove("fa-regular");
+                            }
+                        });
+                        alert("평점이 성공적으로 등록되었습니다.");
+                        setTimeout(() => {
+                            loadAverageScore();
+                            loadRatingBars();
+                        }, 100);
+                        //loadMyTags();
+                        //loadTopTags();
+                    } else {
+                        alert("오류 발생!");
                     }
                 });
-                alert("평점이 성공적으로 등록되었습니다.");
-                setTimeout(() => {
-                    loadAverageScore();
-                    loadRatingBars();
-                }, 100);
-                //loadMyTags();
-                //loadTopTags();
-            } else {
-                alert("오류 발생!");
             }
-        });
-    }
 
-    function setInterest(status) {
-        const movieId = document.body.getAttribute("data-movie-id");
+            function setInterest(status) {
+                const movieId = document.body.getAttribute("data-movie-id");
 
-        fetch(`/movies/${movieId}/interest?status=${status}`, {
-            method: 'POST'
-        }).then(res => {
-            if (res.ok) {
-                // ✅ 모든 아이콘 초기화 ❌ 제거
-                // 🔥 대신 정확히 두 개의 아이콘만 초기화
-                const bookmarkIcon = document.querySelector("i.fa-bookmark");
-                const eyeSlashIcon = document.querySelector("i.fa-eye-slash");
+                fetch(`/movies/${movieId}/interest?status=${status}`, {
+                    method: 'POST'
+                }).then(res => {
+                    if (res.ok) {
+                        // ✅ 모든 아이콘 초기화 ❌ 제거
+                        // 🔥 대신 정확히 두 개의 아이콘만 초기화
+                        const bookmarkIcon = document.querySelector("i.fa-bookmark");
+                        const eyeSlashIcon = document.querySelector("i.fa-eye-slash");
 
-                // 모든 아이콘 일단 기본 상태로 초기화
-                bookmarkIcon.classList.remove("fa-solid", "active");
-                bookmarkIcon.classList.add("fa-regular");
+                        // 모든 아이콘 일단 기본 상태로 초기화
+                        bookmarkIcon.classList.remove("fa-solid", "active");
+                        bookmarkIcon.classList.add("fa-regular");
 
-                eyeSlashIcon.classList.remove("fa-solid", "active");
-                eyeSlashIcon.classList.add("fa-regular");
+                        eyeSlashIcon.classList.remove("fa-solid", "active");
+                        eyeSlashIcon.classList.add("fa-regular");
 
-                // 선택한 아이콘만 활성화
-                const selectedIcon = status === "WATCH_LATER" ? bookmarkIcon : eyeSlashIcon;
-                selectedIcon.classList.add("fa-solid", "active");
-                selectedIcon.classList.remove("fa-regular");
+                        // 선택한 아이콘만 활성화
+                        const selectedIcon = status === "WATCH_LATER" ? bookmarkIcon : eyeSlashIcon;
+                        selectedIcon.classList.add("fa-solid", "active");
+                        selectedIcon.classList.remove("fa-regular");
 
-                alert(
-                    status === "WATCH_LATER"
-                        ? "보고싶어요로 등록되었습니다."
-                        : "관심없어요로 등록되었습니다."
-                );
-            } else {
-                alert("관심 상태 등록에 실패했습니다.");
-            }
-        });
-    }
-
-
-    function createTagListItem(tag) {
-        const li = document.createElement("li");
-        li.textContent = `# ${tag} `;
-
-        const btn = document.createElement("button");
-        btn.textContent = "x";
-        btn.style.marginLeft = "5px";
-        btn.style.background = "none";
-        btn.style.border = "none";
-        btn.style.color = "white";
-        btn.style.cursor = "pointer";
-        btn.onclick = () => deleteTag(tag);
-
-        li.appendChild(btn);
-        return li;
-    }
-    function deleteTag(tagName) {
-        if (!confirm(`'${tagName}' 태그를 삭제할까요?`)) return;
-
-        fetch(`/movies/${movieId}/tags/delete?tagName=${encodeURIComponent(tagName)}`, {
-            method: 'DELETE'
-        }).then(res => {
-            if (res.ok) {
-                alert("삭제되었습니다.");
-                loadMyTags();   // 내 태그 다시 불러오기
-                loadTopTags();  // Top 태그도 다시 반영
-            } else {
-                alert("삭제에 실패했습니다.");
-            }
-        });
-    }
-
-
-    const tagInput = document.getElementById("tagInput");
-    const suggestions = document.getElementById("suggestions");
-    const submitBtn = document.getElementById("submitTag");
-    const myTags = document.getElementById("my-tags");
-    const movieId = document.body.getAttribute("data-movie-id");
-    const userId = document.body.getAttribute("data-user-id");
-
-    let selectedTag = null;
-
-    tagInput.addEventListener("input", async () => {
-        const keyword = tagInput.value.trim();
-        suggestions.innerHTML = '';
-        selectedTag = null;
-        submitBtn.disabled = true;
-
-        if (keyword.length > 0) {
-            const res = await fetch(`/movies/${movieId}/tags/search?keyword=${keyword}`);
-            if (!res.ok) return;
-            const tags = await res.json();
-
-            if (tags.length > 0) {
-                suggestions.style.display = 'block';
-                tags.forEach(tag => {
-                    const div = document.createElement("div");
-                    div.textContent = tag.name;
-                    div.style.padding = "5px";
-                    div.style.cursor = "pointer";
-                    div.addEventListener("click", () => {
-                        tagInput.value = tag.name;
-                        selectedTag = tag;
-                        suggestions.innerHTML = '';
-                        suggestions.style.display = 'none';
-                        submitBtn.disabled = false;
-                    });
-                    suggestions.appendChild(div);
+                        alert(
+                            status === "WATCH_LATER"
+                                ? "보고싶어요로 등록되었습니다."
+                                : "관심없어요로 등록되었습니다."
+                        );
+                    } else {
+                        alert("관심 상태 등록에 실패했습니다.");
+                    }
                 });
             }
-        }
-    });
-
-    submitBtn.addEventListener("click", async () => {
-        if (!selectedTag) {
-            selectedTag = {name:tagInput.value.trim()};
-        }
-
-        if (!selectedTag.name) return;
-
-        const res = await fetch(`/movies/${movieId}/tags/select?tagName=${selectedTag.name}`, {
-            method: 'POST'
-        });
-
-        if (res.status === 409) {
-            const message = await res.text();
-            alert(message);
-            return
-        }
-
-        if (!res.ok) {
-            alert("태그 등록에 실패했습니다.");
-            return;
-        }
-
-        if (![...myTags.children].some(li => li.textContent.trim().startsWith(`# ${selectedTag.name}`))) {
-            const tagElement = createTagListItem(selectedTag.name);
-            myTags.appendChild(tagElement);
-        }
 
 
-        tagInput.value = '';
-        submitBtn.disabled = true;
+            function createTagListItem(tag) {
+                const li = document.createElement("li");
+                li.textContent = `# ${tag} `;
 
-        await loadTopTags();
-    });
+                const btn = document.createElement("button");
+                btn.textContent = "x";
+                btn.style.marginLeft = "5px";
+                btn.style.background = "none";
+                btn.style.border = "none";
+                btn.style.color = "white";
+                btn.style.cursor = "pointer";
+                btn.onclick = () => deleteTag(tag);
 
-    document.addEventListener('click', function (event) {
-        if (!tagInput.contains(event.target) && !suggestions.contains(event.target)) {
-            suggestions.style.display = 'none';
-        }
-    });
+                li.appendChild(btn);
+                return li;
+            }
 
-    tagInput.addEventListener('focus', function () {
-        if (suggestions.children.length > 0) {
-            suggestions.style.display = 'block';
-        }
-    });
+            function deleteTag(tagName) {
+                if (!confirm(`'${tagName}' 태그를 삭제할까요?`)) return;
 
-    document.querySelectorAll(".stars").forEach(star => {
-        star.addEventListener("mouseenter", () => {
-            const score = parseInt(star.dataset.score);
-            document.querySelectorAll(".stars").forEach(s => {
-                if (parseInt(s.dataset.score) <= score) {
-                    s.classList.add("hovered", "fa-solid");
-                    s.classList.remove("fa-regular");
+                fetch(`/movies/${movieId}/tags/delete?tagName=${encodeURIComponent(tagName)}`, {
+                    method: 'DELETE'
+                }).then(res => {
+                    if (res.ok) {
+                        alert("삭제되었습니다.");
+                        loadMyTags();   // 내 태그 다시 불러오기
+                        loadTopTags();  // Top 태그도 다시 반영
+                    } else {
+                        alert("삭제에 실패했습니다.");
+                    }
+                });
+            }
+
+            function scrollToLeft(button) {
+                const list = button.parentElement.querySelector(".recommend-list");
+                list.scrollBy({left: -300, behavior: 'smooth'});
+            }
+
+            function scrollToRight(button) {
+                const list = button.parentElement.querySelector(".recommend-list");
+                list.scrollBy({left: 300, behavior: 'smooth'});
+            }
+
+
+            const tagInput = document.getElementById("tagInput");
+            const suggestions = document.getElementById("suggestions");
+            const submitBtn = document.getElementById("submitTag");
+            const myTags = document.getElementById("my-tags");
+            const movieId = document.body.getAttribute("data-movie-id");
+            const userId = document.body.getAttribute("data-user-id");
+
+            let selectedTag = null;
+
+            tagInput.addEventListener("input", async () => {
+                const keyword = tagInput.value.trim();
+                suggestions.innerHTML = '';
+                selectedTag = null;
+                submitBtn.disabled = true;
+
+                if (keyword.length > 0) {
+                    const res = await fetch(`/movies/${movieId}/tags/search?keyword=${keyword}`);
+                    if (!res.ok) return;
+                    const tags = await res.json();
+
+                    if (tags.length > 0) {
+                        suggestions.style.display = 'block';
+                        tags.forEach(tag => {
+                            const div = document.createElement("div");
+                            div.textContent = tag.name;
+                            div.style.padding = "5px";
+                            div.style.cursor = "pointer";
+                            div.addEventListener("click", () => {
+                                tagInput.value = tag.name;
+                                selectedTag = tag;
+                                suggestions.innerHTML = '';
+                                suggestions.style.display = 'none';
+                                submitBtn.disabled = false;
+                            });
+                            suggestions.appendChild(div);
+                        });
+                    }
                 }
             });
-        });
 
-        star.addEventListener("mouseleave", () => {
-            document.querySelectorAll(".stars").forEach(s => {
-                s.classList.remove("hovered");
-                if (!s.classList.contains("selected")) {
-                    s.classList.remove("fa-solid");
-                    s.classList.add("fa-regular");
+            submitBtn.addEventListener("click", async () => {
+                if (!selectedTag) {
+                    selectedTag = {name: tagInput.value.trim()};
+                }
+
+                if (!selectedTag.name) return;
+
+                const res = await fetch(`/movies/${movieId}/tags/select?tagName=${selectedTag.name}`, {
+                    method: 'POST'
+                });
+
+                if (res.status === 409) {
+                    const message = await res.text();
+                    alert(message);
+                    return
+                }
+
+                if (!res.ok) {
+                    alert("태그 등록에 실패했습니다.");
+                    return;
+                }
+
+                if (![...myTags.children].some(li => li.textContent.trim().startsWith(`# ${selectedTag.name}`))) {
+                    const tagElement = createTagListItem(selectedTag.name);
+                    myTags.appendChild(tagElement);
+                }
+
+
+                tagInput.value = '';
+                submitBtn.disabled = true;
+
+                await loadTopTags();
+            });
+
+            document.addEventListener('click', function (event) {
+                if (!tagInput.contains(event.target) && !suggestions.contains(event.target)) {
+                    suggestions.style.display = 'none';
                 }
             });
-        });
-    });
 
-    // 초기 로딩 시 사용자 태그/Top 태그 불러오기
-    loadMyTags();
-    loadTopTags();
-</script>
+            tagInput.addEventListener('focus', function () {
+                if (suggestions.children.length > 0) {
+                    suggestions.style.display = 'block';
+                }
+            });
+
+            document.querySelectorAll(".stars").forEach(star => {
+                star.addEventListener("mouseenter", () => {
+                    const score = parseInt(star.dataset.score);
+                    document.querySelectorAll(".stars").forEach(s => {
+                        if (parseInt(s.dataset.score) <= score) {
+                            s.classList.add("hovered", "fa-solid");
+                            s.classList.remove("fa-regular");
+                        }
+                    });
+                });
+
+                star.addEventListener("mouseleave", () => {
+                    document.querySelectorAll(".stars").forEach(s => {
+                        s.classList.remove("hovered");
+                        if (!s.classList.contains("selected")) {
+                            s.classList.remove("fa-solid");
+                            s.classList.add("fa-regular");
+                        }
+                    });
+                });
+            });
+
+            // 초기 로딩 시 사용자 태그/Top 태그 불러오기
+            loadMyTags();
+            loadTopTags();
+        </script>
 </body>
 </html>

--- a/backend/src/main/resources/templates/movie/member-details.html
+++ b/backend/src/main/resources/templates/movie/member-details.html
@@ -388,6 +388,7 @@
                                th:attr="data-score=${i}, onclick=|rateMovie(${movie.id},${i})|">
                             </i>
                         </span>
+                        <button class="icon-button" onclick="cancelRating()">평가 취소</button>
                     </div>
                     <div class="rating-center">
                         <strong th:text="${#numbers.formatDecimal(averageScore != null ? averageScore : 0.0, 1, 1)}">0.0</strong>
@@ -552,40 +553,82 @@
                     }
                 });
             }
-
+            function cancelRating() {
+                fetch(`/movies/${movieId}/ratings`, { method: 'DELETE' })
+                    .then(res => {
+                        if (res.ok) {
+                            alert("평가가 취소되었습니다.");
+                            // 별점 UI 초기화
+                            document.querySelectorAll(".stars").forEach(s => {
+                                s.classList.remove("selected", "fa-solid");
+                                s.classList.add("fa-regular");
+                            });
+                            loadAverageScore();
+                            loadRatingBars();
+                        } else {
+                            alert("평가 취소 실패");
+                        }
+                    });
+            }
             function setInterest(status) {
                 const movieId = document.body.getAttribute("data-movie-id");
 
-                fetch(`/movies/${movieId}/interest?status=${status}`, {
-                    method: 'POST'
-                }).then(res => {
-                    if (res.ok) {
-                        // ✅ 모든 아이콘 초기화 ❌ 제거
-                        // 🔥 대신 정확히 두 개의 아이콘만 초기화
-                        const bookmarkIcon = document.querySelector("i.fa-bookmark");
-                        const eyeSlashIcon = document.querySelector("i.fa-eye-slash");
+                const bookmarkIcon = document.querySelector("i.fa-bookmark");
+                const eyeSlashIcon = document.querySelector("i.fa-eye-slash");
 
-                        // 모든 아이콘 일단 기본 상태로 초기화
-                        bookmarkIcon.classList.remove("fa-solid", "active");
-                        bookmarkIcon.classList.add("fa-regular");
+                const isBookmarkActive = bookmarkIcon.classList.contains("active");
+                const isEyeSlashActive = eyeSlashIcon.classList.contains("active");
 
-                        eyeSlashIcon.classList.remove("fa-solid", "active");
-                        eyeSlashIcon.classList.add("fa-regular");
+                const isSameClicked =
+                    (status === "WATCH_LATER" && isBookmarkActive) ||
+                    (status === "NOT_INTERESTED" && isEyeSlashActive);
 
-                        // 선택한 아이콘만 활성화
-                        const selectedIcon = status === "WATCH_LATER" ? bookmarkIcon : eyeSlashIcon;
-                        selectedIcon.classList.add("fa-solid", "active");
-                        selectedIcon.classList.remove("fa-regular");
+                if (isSameClicked) {
+                    // 👇 같은 상태 다시 클릭 → 취소 요청 (DELETE)
+                    fetch(`/movies/${movieId}/interest`, {
+                        method: 'DELETE'
+                    }).then(res => {
+                        if (res.ok) {
+                            // 아이콘 초기화
+                            bookmarkIcon.classList.remove("fa-solid", "active");
+                            bookmarkIcon.classList.add("fa-regular");
 
-                        alert(
-                            status === "WATCH_LATER"
-                                ? "보고싶어요로 등록되었습니다."
-                                : "관심없어요로 등록되었습니다."
-                        );
-                    } else {
-                        alert("관심 상태 등록에 실패했습니다.");
-                    }
-                });
+                            eyeSlashIcon.classList.remove("fa-solid", "active");
+                            eyeSlashIcon.classList.add("fa-regular");
+
+                            alert("관심 상태가 취소되었습니다.");
+                        } else {
+                            alert("관심 상태 취소에 실패했습니다.");
+                        }
+                    });
+                } else {
+                    // 👇 새로운 관심 상태 등록
+                    fetch(`/movies/${movieId}/interest?status=${status}`, {
+                        method: 'POST'
+                    }).then(res => {
+                        if (res.ok) {
+                            // 아이콘 초기화
+                            bookmarkIcon.classList.remove("fa-solid", "active");
+                            bookmarkIcon.classList.add("fa-regular");
+
+                            eyeSlashIcon.classList.remove("fa-solid", "active");
+                            eyeSlashIcon.classList.add("fa-regular");
+
+                            // 선택한 아이콘 활성화
+                            const selectedIcon = status === "WATCH_LATER" ? bookmarkIcon : eyeSlashIcon;
+                            selectedIcon.classList.add("fa-solid", "active");
+                            selectedIcon.classList.remove("fa-regular");
+
+                            alert(
+                                status === "WATCH_LATER"
+                                    ? "보고싶어요로 등록되었습니다."
+                                    : "관심없어요로 등록되었습니다."
+                            );
+                        } else {
+                            alert("관심 상태 등록에 실패했습니다.");
+                        }
+                    });
+                }
             }
 
 

--- a/backend/src/main/resources/templates/movie/member-details.html
+++ b/backend/src/main/resources/templates/movie/member-details.html
@@ -346,7 +346,7 @@
             <div class="graph">
                 <div th:each="bar : ${ratingBars}" class="bar-group">
                     <div class="bar-vertical" th:style="'height:' + (${bar.percent} * 10) + 'px'"></div>
-                    <div class="bar-label" th:text="${bar.score} + '점'"></div>
+                    <div class="bar-label" th:text="${bar.score} + 'point'"></div>
                 </div>
             </div>
         </div>
@@ -354,21 +354,20 @@
         <div class="info-section">
             <div class="movie-title" th:text="${movie.title}">영화 제목</div>
             <div class="info-text">
-                <strong>장르:</strong>
+                <strong>Genre :</strong>
                 <span th:each="genre : ${genres}" th:text="${genre.name} + ' '"></span>
             </div>
             <div class="info-text">
-                <span th:text="'개봉일: ' + (${movie.releaseDate} != null ? ${#temporals.format(movie.releaseDate, 'yyyy-MM-dd')} : '정보없음')"></span>
-                |
-                <span th:text="'국가: ' + (${movie.country} != null ? ${movie.country} : '정보없음')"></span> |
-                <span th:text="'관람등급: ' + (${movie.certification} != null ? ${movie.certification} : '정보없음')"></span> |
-                <span th:text="'공개 여부: ' + (${movie.isReleased} ? '공개됨' : '미공개')"></span>
+                <span th:text="'Release Date : ' + (${movie.releaseDate} != null ? ${#temporals.format(movie.releaseDate, 'yyyy-MM-dd')} : 'No information')"></span> |
+                <span th:text="'Country : ' + (${movie.country} != null ? ${movie.country} : 'No information')"></span> |
+                <span th:text="'Certification : ' + (${movie.certification} != null ? ${movie.certification} : 'No information')"></span> |
+                <span th:text="'undisclosed : ' + (${movie.isReleased} ? 'release' : 'undisclosed')"></span>
             </div>
 
             <div class="section-divider"></div>
             <div class="info-text">
-                <strong>줄거리 : </strong>
-                <span th:text="${movie.overview != null ? movie.overview : '정보없음'}"></span>
+                <strong>OverView : </strong>
+                <span th:text="${movie.overview != null ? movie.overview : 'No information'}"></span>
             </div>
 
             <div class="section-divider"></div>
@@ -376,28 +375,28 @@
             <div class="rating-wrapper">
                 <div class="rating-flex">
                     <div class="rating-left rating-inline">
-                        <strong class="rating-label">평가 남기기:</strong>
+                        <strong class="rating-label">Leave a rating :</strong>
                         <span class="rating-stars" th:each="i : ${#numbers.sequence(1,5)}">
                             <i class="fa-star stars" th:classappend="${userRating >= i} ? 'fa-solid selected' : 'fa-regular'"
                                 th:attr="data-score=${i}, onclick=|rateMovie(${movie.id},${i})|">
                             </i>
                         </span>
-                        <button class="icon-button cancel-btn" onclick="cancelRating()">평가 취소</button>
+                        <button class="icon-button cancel-btn" onclick="cancelRating()">Cancel</button>
                     </div>
 
 
                     <div class="rating-center">
                         <strong th:text="${#numbers.formatDecimal(averageScore != null ? averageScore : 0.0, 1, 1)}">0.0</strong>
-                        <div style="font-size: 14px; color: #ccc;">평균 별점</div>
+                        <div style="font-size: 14px; color: #ccc;">Average Star</div>
                     </div>
                     <div class="rating-right">
                         <button class="icon-button" onclick="setInterest('WATCH_LATER')">
                             <i th:class="'fa-bookmark ' + (${interestStatus != null and interestStatus.name() == 'WATCH_LATER'} ? 'fa-solid active' : 'fa-regular')"> </i>
-                            보고싶어요
+                            Interest
                         </button>
                         <button class="icon-button" onclick="setInterest('NOT_INTERESTED')">
                             <i th:class="'fa-eye-slash ' + (${interestStatus != null and interestStatus.name() == 'NOT_INTERESTED'} ? 'fa-solid active' : 'fa-regular')"> </i>
-                            관심없어요
+                            UnInterest
                         </button>
                     </div>
                 </div>
@@ -406,16 +405,16 @@
             <div class="section-divider"></div>
 
             <div class="tag-selection">
-                <label for="tagInput"><strong>태그 남기기:</strong></label>
-                <input type="text" id="tagInput" class="browser-default" placeholder="태그를 입력하세요..." autocomplete="off"/>
+                <label for="tagInput"><strong>Leave a tag :</strong></label>
+                <input type="text" id="tagInput" class="browser-default" placeholder="Please enter tags..." autocomplete="off"/>
                 <div id="suggestions"></div>
-                <button id="submitTag" disabled>태그 남기기</button>
+                <button id="submitTag" disabled>Leave a tag</button>
 
             </div>
             <div class="section-divider"></div>
 
             <div class="my-tags">
-                <h4>내가 남긴 태그</h4>
+                <h4>My Tags</h4>
                 <ul id="my-tags">
                     <li th:each="tag : ${userTags}" th:text="'# ' + ${tag.name}"></li>
                 </ul>
@@ -433,9 +432,9 @@
             <div class="section-divider"></div>
 
             <div class="cast-section">
-                <div><strong>감독:</strong> <span th:each="d, stat : ${directors}"
+                <div><strong>Director :</strong> <span th:each="d, stat : ${directors}"
                                                 th:utext="${d.name} + (!${stat.last} ? ' | ' : '')"></span></div>
-                <div><strong>출연:</strong> <span th:each="a, stat : ${actors}"
+                <div><strong>Casting :</strong> <span th:each="a, stat : ${actors}"
                                                 th:utext="${a.name} + (!${stat.last} ? ' | ' : '')"></span></div>
             </div>
         </div>
@@ -443,7 +442,7 @@
     <div class="section-divider"></div>
     <div style="max-width: 1200px; margin: 0 auto; padding: 0 30px;">
         <div class="genre-recommend-container">
-            <h3 class="recommend-title">장르가 비슷한 작품:</h3>
+            <h3 class="recommend-title">Recommendations of similar genres :</h3>
             <div class="slider-wrapper">
                 <button class="slider-button left" onclick="scrollToLeft(this)">&#10094;</button>
                 <div class="recommend-list"
@@ -513,7 +512,7 @@
 
             const label = document.createElement("div");
             label.className = "bar-label";
-            label.textContent = bar.score + "점";
+            label.textContent = bar.score + "point";
 
             group.appendChild(barDiv);
             group.appendChild(label);
@@ -537,7 +536,7 @@
                         s.classList.remove("fa-regular");
                     }
                 });
-                alert("평점이 성공적으로 등록되었습니다.");
+                alert("Your rating has been successfully registered.");
                 setTimeout(() => {
                     loadAverageScore();
                     loadRatingBars();
@@ -545,7 +544,7 @@
                 //loadMyTags();
                 //loadTopTags();
             } else {
-                alert("오류 발생!");
+                alert("An error occurred!");
             }
         });
     }
@@ -554,14 +553,14 @@
         const ratedStars = document.querySelectorAll(".stars.selected");
 
         if (ratedStars.length === 0) {
-            alert("평가가 없습니다.");
+            alert("There are no ratings.");
             return;
         }
 
         fetch(`/movies/${movieId}/ratings`, {method: 'DELETE'})
             .then(res => {
                 if (res.ok) {
-                    alert("평가가 취소되었습니다.");
+                    alert("The evaluation has been cancelled.");
                     document.querySelectorAll(".stars").forEach(s => {
                         s.classList.remove("selected", "fa-solid");
                         s.classList.add("fa-regular");
@@ -569,12 +568,10 @@
                     loadAverageScore();
                     loadRatingBars();
                 } else {
-                    alert("평가 취소 실패");
+                    alert("Failed to cancel evaluation");
                 }
             });
     }
-
-
     function setInterest(status) {
         const movieId = document.body.getAttribute("data-movie-id");
 
@@ -601,9 +598,9 @@
                     eyeSlashIcon.classList.remove("fa-solid", "active");
                     eyeSlashIcon.classList.add("fa-regular");
 
-                    alert("관심 상태가 취소되었습니다.");
+                    alert("Your interest has been cancelled.");
                 } else {
-                    alert("관심 상태 취소에 실패했습니다.");
+                    alert("Failed to cancel interest status.");
                 }
             });
         } else {
@@ -626,11 +623,11 @@
 
                     alert(
                         status === "WATCH_LATER"
-                            ? "보고싶어요로 등록되었습니다."
-                            : "관심없어요로 등록되었습니다."
+                            ? "It has been registered as I want to see you."
+                            : "Registered as not interested."
                     );
                 } else {
-                    alert("관심 상태 등록에 실패했습니다.");
+                    alert("Failed to register interest status.");
                 }
             });
         }
@@ -655,17 +652,17 @@
     }
 
     function deleteTag(tagName) {
-        if (!confirm(`'${tagName}' 태그를 삭제할까요?`)) return;
+        if (!confirm(`'${tagName}' Should I delete this tag?`)) return;
 
         fetch(`/movies/${movieId}/tags/delete?tagName=${encodeURIComponent(tagName)}`, {
             method: 'DELETE'
         }).then(res => {
             if (res.ok) {
-                alert("삭제되었습니다.");
+                alert("It has been deleted.");
                 loadMyTags();   // 내 태그 다시 불러오기
                 loadTopTags();  // Top 태그도 다시 반영
             } else {
-                alert("삭제에 실패했습니다.");
+                alert("Deletion failed.");
             }
         });
     }
@@ -741,7 +738,7 @@
         }
 
         if (!res.ok) {
-            alert("태그 등록에 실패했습니다.");
+            alert("Tag registration failed");
             return;
         }
 

--- a/backend/src/main/resources/templates/movie/member-details.html
+++ b/backend/src/main/resources/templates/movie/member-details.html
@@ -91,6 +91,7 @@
             width: 300px;
             border-radius: 10px;
         }
+
         .graph {
             width: 300px;
             display: flex;
@@ -226,6 +227,7 @@
             padding: 0 5px;
             font-size: 14px;
         }
+
         #suggestions {
             position: absolute;
             top: calc(100% + 4px);
@@ -284,18 +286,32 @@
         .cast-section div {
             margin-bottom: 10px;
         }
+
         h3, h4 {
             font-size: 18px;
             font-weight: bold;
             margin: 10px 0;
             color: white;
         }
+
+        /* 모든 버튼 기본 focus 효과 제거 (불필요한 초록 테두리 제거) */
+        button:focus,
+        .icon-button:focus {
+            outline: none;
+            box-shadow: none;
+            background-color: transparent;
+        }
+
+        /* 슬라이더 버튼만 focus 시 초록색 배경 유지 */
+        .slider-button:focus {
+            background-color: #27c29c;
+        }
+
     </style>
 </head>
 <body th:attr="data-movie-id=${movie.id}, data-user-id=${userId}">
 <th:block th:replace="fragments :: frg_header"></th:block>
 <div class="overlay">
-
     <div class="main-section">
         <div class="poster">
             <img th:src="${movie.poster != null ? 'https://image.tmdb.org/t/p/w500' + movie.poster : '/images/default.jpg'}"
@@ -622,11 +638,13 @@
     function scrollToLeft(button) {
         const list = button.parentElement.querySelector(".recommend-list");
         list.scrollBy({left: -300, behavior: 'smooth'});
+        button.blur();
     }
 
     function scrollToRight(button) {
         const list = button.parentElement.querySelector(".recommend-list");
         list.scrollBy({left: 300, behavior: 'smooth'});
+        button.blur();
     }
 
 


### PR DESCRIPTION
## 📌 과제 설명
- 장르 일치 작품 10개 리스트 목록  보이도록 하였습니다.
- 별점 및 관심도 저장 후 취소 할 수 있는 기능을 추가 하였습니다.
- 상세페이지 상단 바를 `fragments.html` 요소와 통일 시켰습니다.
- 상세페이지 정보를 영어로 변경하였습니다.

## 👩‍💻 요구 사항과 구현 내용 
[src]
- [장르 일치 작품]
  - `MovieDetailsController` : 일치하는 작품의 데이터 model로 담아 전달 기능 추가
  - `similarmovieDto` - 장르 일치하는 영화 id를 기반으로 영화의 제목 포스터이미지 정보 전달 dto 생성
  - `MovieRecommendService` : 영화 ids에 해당하는 각 영화 정보 dto에 매핑하는 로직 구현
  - `MovieNeo4jService` : Neo4j에서 장르일치하는 영화 ids 정보 저장
  - `GenreRecommendService: 각 RDB와 neo4j에서 가져온 정보들을 통합하여 MovieNeo4jService에 return 

- [별점 및 관심도 삭제]
  -  `InterestApiController` , `RatingApiController` : 사용자 삭제 기능 요청 시 삭제로직 추가
 
[infra]
 - `MovieTagEntity` : `BaseEntity` 상속 받도록 수정, createdAt 테이블은 삭제
---
[resource]
 - `guest-details,member-details` :  `fragments.html` 에 있는 상단바 구성 이용하여 통일 및  UI 개선

## ✅ 피드백 반영사항 

## ✅ PR 포인트 & 궁금한 점
