### PR TITLE
Refactor: infra/error 에 있는 공통 error에를 기준으로 컨트롤러 수정

### DIFF
--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/details/InterestApiController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/details/InterestApiController.java
@@ -3,38 +3,41 @@ package com.grepp.smartwatcha.app.controller.api.details;
 
 import com.grepp.smartwatcha.app.model.auth.CustomUserDetails;
 import com.grepp.smartwatcha.app.model.details.service.jpaservice.InterestJpaService;
+import com.grepp.smartwatcha.infra.error.exceptions.CommonException;
 import com.grepp.smartwatcha.infra.jpa.enums.Status;
+import com.grepp.smartwatcha.infra.response.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@RequiredArgsConstructor
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/movies/{id}/interest")
 public class InterestApiController {
     private final InterestJpaService interestJpaService;
 
     @PostMapping
-    public ResponseEntity<Void> setInterestStatus(
+    public void setInterestStatus(
             @PathVariable("id") Long movieId,
             @RequestParam Status status,
             @AuthenticationPrincipal CustomUserDetails userDetails
             ){
         if(userDetails == null){
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            throw new CommonException(ResponseCode.BAD_REQUEST);
         }
         String userEmail = userDetails.getUsername();
         interestJpaService.saveOrUpdateInterest(userEmail, movieId, status);
-        return ResponseEntity.ok().build();
     }
     @DeleteMapping
-    public ResponseEntity<Void> deleteInterest(@PathVariable("id") Long movieId,
+    public void  deleteInterest(@PathVariable("id") Long movieId,
                                                @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails.getUser().getId();
+        if(userId == null){
+            throw new CommonException(ResponseCode.BAD_REQUEST);
+        }
         interestJpaService.deleteInterest(userId, movieId);
-        return ResponseEntity.noContent().build();
     }
 }
 

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/details/RatingApiController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/details/RatingApiController.java
@@ -4,6 +4,8 @@ import com.grepp.smartwatcha.app.model.auth.CustomUserDetails;
 import com.grepp.smartwatcha.app.model.details.dto.jpadto.RatingBarDto;
 import com.grepp.smartwatcha.app.model.details.dto.jpadto.RatingRequestDto;
 import com.grepp.smartwatcha.app.model.details.service.jpaservice.RatingJpaService;
+import com.grepp.smartwatcha.infra.error.exceptions.CommonException;
+import com.grepp.smartwatcha.infra.response.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,7 +21,7 @@ public class RatingApiController {
     private final RatingJpaService ratingJpaService;
 
     @PostMapping
-    public ResponseEntity<String> addRating(
+    public void addRating(
             @PathVariable("id") Long movieId,
             @RequestBody RatingRequestDto dto,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -27,22 +29,24 @@ public class RatingApiController {
         Long userId = userDetails.getId();
         dto.setUserId(userId);
         dto.setMovieId(movieId);
-
+        if(userId == null || movieId == null) {
+            throw new CommonException(ResponseCode.BAD_REQUEST);
+        }
         ratingJpaService.addRating(dto);
-        return ResponseEntity.ok("평점이 성공적으로 등록되었습니다.");
     }
     @DeleteMapping
-    public ResponseEntity<Void> deleteRating(@PathVariable("id") Long movieId,
+    public void deleteRating(@PathVariable("id") Long movieId,
                                              @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long userId = userDetails.getUser().getId();
+        if(userId == null){
+            throw new CommonException(ResponseCode.BAD_REQUEST);
+        }
         ratingJpaService.deleteRatingByUser(userId, movieId);
-        return ResponseEntity.noContent().build(); // 204 No Content 반환
     }
     @GetMapping("/average")
-    public ResponseEntity<Double> getAverageRating(
+    public void getAverageRating(
             @PathVariable("id") Long movieId) {
-        double average = ratingJpaService.getAverageRating(movieId);
-        return ResponseEntity.ok(average);
+        ratingJpaService.getAverageRating(movieId);
     }
 
     @GetMapping("/bars")

--- a/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/details/TagApiController.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/controller/api/details/TagApiController.java
@@ -5,7 +5,9 @@ import com.grepp.smartwatcha.app.model.details.dto.jpadto.JpaTagDto;
 import com.grepp.smartwatcha.app.model.details.dto.neo4jdto.Neo4jTagDto;
 import com.grepp.smartwatcha.app.model.details.service.jpaservice.TagJpaService;
 import com.grepp.smartwatcha.app.model.details.service.neo4jservice.TagNeo4jService;
+import com.grepp.smartwatcha.infra.error.exceptions.CommonException;
 import com.grepp.smartwatcha.infra.jpa.entity.UserEntity;
+import com.grepp.smartwatcha.infra.response.ResponseCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,17 +27,15 @@ public class TagApiController {
     }
 
     @GetMapping("/user")
-    public ResponseEntity<List<String>> getUserTags(
+    public List<String> getUserTags(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("id") Long movieId
     ) {
         UserEntity user = userDetails.getUser();
-        List<String> tagNames = tagJpaService.getUserTags(user, movieId)
+        return tagJpaService.getUserTags(user, movieId)
                 .stream()
                 .map(tag -> tag.getTag().getName())
                 .toList();
-
-        return ResponseEntity.ok(tagNames);
     }
     @GetMapping("/search")
     public List<JpaTagDto> searchTags(@RequestParam String keyword) {
@@ -43,7 +43,7 @@ public class TagApiController {
     }
 
     @PostMapping("/select")
-    public ResponseEntity<String> selectTag(
+    public void selectTag(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("id") Long movieId,
             @RequestParam String tagName
@@ -51,32 +51,22 @@ public class TagApiController {
         UserEntity user = userDetails.getUser();
         try {
             tagJpaService.selectTag(user, movieId, tagName);
-            return ResponseEntity.ok().build();
         } catch (IllegalStateException e) {
-            return ResponseEntity
-                    .status(HttpStatus.CONFLICT)
-                    .body(e.getMessage());
+            throw new CommonException(ResponseCode.BAD_REQUEST);
         }
     }
     @DeleteMapping("/delete")
-    public ResponseEntity<?> deleteUserTag(
+    public void deleteUserTag(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable("id") Long movieId,
             @RequestParam String tagName
     ) {
         tagJpaService.deleteUserTag(userDetails.getUser(), movieId, tagName);
-        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/top6")
     public List<Neo4jTagDto> top6Tags(@RequestParam Long movieId) {
         return tagService.getTop6Tags(movieId);
     }
-
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException e) {
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
-    }
-
 
 }

--- a/backend/src/main/resources/templates/movie/member-details.html
+++ b/backend/src/main/resources/templates/movie/member-details.html
@@ -520,12 +520,13 @@
         });
     }
 
-    function rateMovie(movieId, score) {
-        fetch(`/movies/${movieId}/ratings`, {
+    async function rateMovie(movieId, score) {
+        const res = await fetch(`/movies/${movieId}/ratings`, {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({movieId, score})
-        }).then(res => {
+        });
+
             if (res.ok) {
                 document.querySelectorAll(".stars").forEach(s => {
                     s.classList.remove("selected", "fa-solid");
@@ -544,12 +545,12 @@
                 //loadMyTags();
                 //loadTopTags();
             } else {
-                alert("An error occurred!");
+                const error = await res.json();
+                alert(error.message || "An error occurred!");
             }
-        });
     }
 
-    function cancelRating() {
+    async function cancelRating() {
         const ratedStars = document.querySelectorAll(".stars.selected");
 
         if (ratedStars.length === 0) {
@@ -557,22 +558,21 @@
             return;
         }
 
-        fetch(`/movies/${movieId}/ratings`, {method: 'DELETE'})
-            .then(res => {
+        const res = await fetch(`/movies/${movieId}/ratings`, {method: 'DELETE'});
                 if (res.ok) {
                     alert("The evaluation has been cancelled.");
                     document.querySelectorAll(".stars").forEach(s => {
                         s.classList.remove("selected", "fa-solid");
                         s.classList.add("fa-regular");
                     });
-                    loadAverageScore();
-                    loadRatingBars();
+                    await loadAverageScore();
+                    await loadRatingBars();
                 } else {
-                    alert("Failed to cancel evaluation");
+                    const error = await res.json();
+                    alert(error.message ||"Failed to cancel evaluation");
                 }
-            });
     }
-    function setInterest(status) {
+     async function setInterest(status) {
         const movieId = document.body.getAttribute("data-movie-id");
 
         const bookmarkIcon = document.querySelector("i.fa-bookmark");
@@ -587,9 +587,9 @@
 
         if (isSameClicked) {
             // 👇 같은 상태 다시 클릭 → 취소 요청 (DELETE)
-            fetch(`/movies/${movieId}/interest`, {
+            const res = await fetch(`/movies/${movieId}/interest`, {
                 method: 'DELETE'
-            }).then(res => {
+            });
                 if (res.ok) {
                     // 아이콘 초기화
                     bookmarkIcon.classList.remove("fa-solid", "active");
@@ -600,14 +600,16 @@
 
                     alert("Your interest has been cancelled.");
                 } else {
-                    alert("Failed to cancel interest status.");
+                    const error = await res.json();
+                    alert(error.message || "Failed to cancel interest status.");
                 }
-            });
+
         } else {
             // 👇 새로운 관심 상태 등록
-            fetch(`/movies/${movieId}/interest?status=${status}`, {
+            const res = await fetch(`/movies/${movieId}/interest?status=${status}`, {
                 method: 'POST'
-            }).then(res => {
+            });
+
                 if (res.ok) {
                     // 아이콘 초기화
                     bookmarkIcon.classList.remove("fa-solid", "active");
@@ -627,9 +629,9 @@
                             : "Registered as not interested."
                     );
                 } else {
-                    alert("Failed to register interest status.");
+                    const error = await res.json();
+                    alert(error.message || "Failed to register interest status.");
                 }
-            });
         }
     }
 
@@ -651,20 +653,20 @@
         return li;
     }
 
-    function deleteTag(tagName) {
+    async function deleteTag(tagName) {
         if (!confirm(`'${tagName}' Should I delete this tag?`)) return;
 
-        fetch(`/movies/${movieId}/tags/delete?tagName=${encodeURIComponent(tagName)}`, {
+        const res = await fetch(`/movies/${movieId}/tags/delete?tagName=${encodeURIComponent(tagName)}`, {
             method: 'DELETE'
-        }).then(res => {
+        });
             if (res.ok) {
                 alert("It has been deleted.");
                 loadMyTags();   // 내 태그 다시 불러오기
                 loadTopTags();  // Top 태그도 다시 반영
             } else {
-                alert("Deletion failed.");
+                const error = await res.json();
+                alert( error.message || "Deletion failed.");
             }
-        });
     }
 
     function scrollToLeft(button) {
@@ -731,14 +733,9 @@
             method: 'POST'
         });
 
-        if (res.status === 409) {
-            const message = await res.text();
-            alert(message);
-            return
-        }
-
         if (!res.ok) {
-            alert("Tag registration failed");
+            const error = await res.json();
+            alert(error.message || "Tag registration failed");
             return;
         }
 


### PR DESCRIPTION
## 📌 과제 설명 
 - 상세페이지 관련 api,web 컨트롤러 수정 및 추가

## 👩‍💻 요구 사항과 구현 내용
 - `InterestApiController`,`RatingApinController`,`TagApiController` 
   : 기존 ResponseEntity를 통해 예외응답을 직접 반환하였던걸 RestApiExceptionAdvice를 기반으로 
     공통예외 처리로 변경하여 컨트롤러별 개인 예외응답처리 코드 제거, html에서 json 기반 응답 처리하도록 변경
 - `MovieDetailsController` 
   : WebExceptionAdvice를 기반으로 사용자 인증 정보 유효성 검사를 수행하여 
    유저 정보가 없거나 비정상일 경우, 예외를 발생시켜 error/redirect.html 페이지로 이동하도록 처리 하도록 코드 수정하였음

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
 - RatingApiCotnroller에서 delete 수행 시 유저기반으로 별점 삭제 하는것이므로 userId가없으면 
   `badrequest` 반환하돌고 하였는데 이 부분 불필요 코드인지 판단이 헷갈립니다. (그냥 단순 삭제기능으로 보면 되는건지)
 - 오류 발생 시 `member-html` 에서 오류 메세지 반환하는데 영어로 페이지 만든다고해서 
   임의 오류메세지 영어로 지정 해놨는데 이부분 그냥 기본 오류메세지 사용해야하는지 궁금합니다.