### PR TITLE
docs: Spring Security 관련 클래스 설명 주석 추가 및 에러 처리 개선(Feature/0501-3)

### DIFF
--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/auth/CustomUserDetails.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/auth/CustomUserDetails.java
@@ -2,26 +2,30 @@ package com.grepp.smartwatcha.app.model.auth;
 
 import com.grepp.smartwatcha.infra.jpa.entity.UserEntity;
 import com.grepp.smartwatcha.infra.jpa.enums.Role;
-
-
 import java.util.Collection;
 import java.util.Collections;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+// Spring Security 인증 시 사용되는 사용자 정보 클래스
+// UserEntity 를 기반으로 UserDetails 인터페이스를 구현하여,
+// Spring Security 가 인증 후 세션에서 사용자 정보를 추적할 수 있도록 제공
+
 public class CustomUserDetails implements UserDetails {
 
   private final UserEntity user;
 
+  // 생성자: 인증 대상이 되는 사용자 정보를 주입받음
   public CustomUserDetails(UserEntity user) {
     this.user = user;
   }
 
-  public UserEntity getUser() {
+  public UserEntity getUser() { // UserEntity getter
     return user;
   }
 
+  // 사용자의 권한(Role)을 반환 - ROLE_ 접두사를 붙여 Spring Security 규칙에 맞게 반환
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
     return Collections.singleton(
@@ -32,42 +36,42 @@ public class CustomUserDetails implements UserDetails {
   @Override
   public String getPassword() {
     return user.getPassword();
-  }
+  } // 사용자 비밀번호 반환
 
   @Override
   public String getUsername() {
     return user.getEmail();
-  }
+  } // 사용자 이름 (이메일) 반환
 
   @Override
   public boolean isAccountNonExpired() {
     return true;
-  }
+  } // 계정 만료 여부 반환
 
   @Override
   public boolean isAccountNonLocked() {
     return true;
-  }
+  } // 계정 잠김 여부 반환
 
   @Override
   public boolean isCredentialsNonExpired() {
     return true;
-  }
+  } // 자격 증명(비밀번호 등) 만료 여부
 
   @Override
   public boolean isEnabled() {
     return true;
-  }
+  } // 계정 활성화 여부
 
   public String getName() {
     return user.getName();
-  }
+  } // 사용자 이름(실명) 반환
 
   public Role getRole() {
     return user.getRole();
-  }
+  } // 사용자 권한(Role) 반환
 
   public Long getId() {
     return user.getId();
-  }
+  } // 사용자 ID 반환
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/auth/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/auth/CustomUserDetailsService.java
@@ -1,24 +1,37 @@
 package com.grepp.smartwatcha.app.model.auth;
 
+import com.grepp.smartwatcha.infra.error.exceptions.CommonException;
 import com.grepp.smartwatcha.infra.jpa.entity.UserEntity;
-
 import com.grepp.smartwatcha.app.model.user.repository.UserJpaRepository;
+import com.grepp.smartwatcha.infra.response.ResponseCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+// Spring Security 의 사용자 인증 과정에서 사용되는 커스텀 UserDetailsService 구현체
+// - 입력받은 이메일(email)로 DB 에서 유저 정보를 조회
+// - 존재하지 않을 경우 CommonException(UNAUTHORIZED) 예외 발생
+// - 존재할 경우 CustomUserDetails 객체로 변환하여 반환
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
   private final UserJpaRepository userRepository;
 
+  // Spring Security 의 로그인 시 호출되는 메서드
   @Override
   public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
     UserEntity user = userRepository.findByEmail(email)
-        .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+        .orElseThrow(() -> {
+          log.info("🔒 [인증 실패] 존재하지 않는 이메일로 로그인 시도: {}", email);
+          return new CommonException(ResponseCode.UNAUTHORIZED);
+        });
+
     return new CustomUserDetails(user);
   }
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/infra/config/SecurityConfig.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/infra/config/SecurityConfig.java
@@ -16,6 +16,12 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
+// Spring Security 전체 설정 클래스
+// 기능:
+    // - 사용자 인증 및 권한 관리
+    // - 로그인/로그아웃 커스터마이징
+    // - 예외 핸들링
+    // - Remember-Me 설정 등
 
 @Configuration
 @EnableWebSecurity
@@ -23,10 +29,12 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
     @Value("${remember-me.key}")
-    private String rememberMeKey;
+    private String rememberMeKey; // remember-me 기능에서 사용할 고유 키
 
     private final CustomUserDetailsService userDetailsService;
 
+    // 사용자 인증을 위한 AuthenticationManager 빈 설정
+    // 사용자 정보 및 비밀번호 암호화 방식을 등록
     @Bean
     public AuthenticationManager authManager(HttpSecurity http, PasswordEncoder passwordEncoder)
         throws Exception {
@@ -36,48 +44,58 @@ public class SecurityConfig {
         return builder.build();
     }
 
+    // Security Filter Chain 구성
+    // HTTP 보안 설정 (로그인, 권한, 예외처리 등)
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+            // CSRF 보호 비활성화 (필요 시 활성화 가능)
             .csrf(csrf -> csrf.disable())
 
+            // 로그인 설정
             .formLogin(form -> form
-                .loginPage("/login")
-                .loginProcessingUrl("/login")
-                .usernameParameter("email")
-                .passwordParameter("password")
-                .successHandler(new CustomLoginSuccessHandler())
-                .failureHandler(new CustomLoginFailureHandler())
+                .loginPage("/login")                // 사용자 정의 로그인 페이지
+                .loginProcessingUrl("/login")       // 로그인 form action 경로
+                .usernameParameter("email")         // 아이디 파라미터 이름
+                .passwordParameter("password")      // 비밀번호 파라미터 이름
+                .successHandler(new CustomLoginSuccessHandler())  // 로그인 성공 핸들러
+                .failureHandler(new CustomLoginFailureHandler())  // 로그인 성공 핸들러
                 .permitAll()
             )
 
+            // 로그아웃 설정
             .logout(logout -> logout
-                .logoutUrl("/logout")
-                .logoutSuccessUrl("/")
-                .invalidateHttpSession(true)
-                .deleteCookies("JSESSIONID", "remember-me")
+                .logoutUrl("/logout")                   // 로그아웃 요청 URL
+                .logoutSuccessUrl("/")                  // 로그아웃 성공 시 이동할 URL
+                .invalidateHttpSession(true)            // 세션 무효화
+                .deleteCookies("JSESSIONID", "remember-me") // 쿠키 삭제
             )
 
+            // remember-me 설정
             .rememberMe(rm -> rm
-                .key(rememberMeKey)
-                .tokenValiditySeconds(86400 * 30)
-                .userDetailsService(userDetailsService)
-                .rememberMeParameter("remember-me")
+                .key(rememberMeKey)                     // 토큰 키 (고유 식별용)
+                .tokenValiditySeconds(86400 * 30)       // 토큰 유효기간 (30일)
+                .userDetailsService(userDetailsService) // 사용자 정보 제공자
+                .rememberMeParameter("remember-me")     // form 의 checkbox name
             )
 
+            // 인가 실패(403) 처리 핸들러 등록
             .exceptionHandling(ex -> ex
                 .accessDeniedHandler(new CustomAccessDeniedHandler())
             )
 
+            // 요청 URL 별 접근 권한 설정
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/admin/**").hasRole("ADMIN")
-                .requestMatchers("/", "/login", "/css/**", "/js/**", "/images/**", "/error").permitAll()
-                .anyRequest().permitAll()
+                .requestMatchers("/admin/**").hasRole("ADMIN")  // 관리자만 접근 가능
+                .requestMatchers("/", "/login", "/css/**", "/js/**", "/images/**", "/error").permitAll() // 전체 공개
+                .anyRequest().permitAll()                        // 그 외 요청도 기본적으로 허용
             );
 
         return http.build();
     }
 
+    // 비밀번호 암호화에 사용되는 PasswordEncoder 빈
+    // 다양한 암호화 알고리즘을 지원하는 delegating encoder 사용
     @Bean
     public PasswordEncoder passwordEncoder() {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();

--- a/backend/src/main/java/com/grepp/smartwatcha/infra/handler/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/infra/handler/CustomAccessDeniedHandler.java
@@ -7,8 +7,13 @@ import java.io.IOException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 
+// Spring Security 에서 인가(Authorization) 실패 시 처리하는 핸들러
+// -> 인증은 되었지만, 요청한 리소스에 대한 권한이 없는 경우 (403 Forbidden)
+// 처리 방식 : "/?error=access_denied" 경로로 리다이렉트
+
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
+  // 인가 실패 시 호출되는 메서드
   @Override
   public void handle(HttpServletRequest request, HttpServletResponse response,
       AccessDeniedException accessDeniedException) throws IOException, ServletException {

--- a/backend/src/main/java/com/grepp/smartwatcha/infra/handler/CustomLoginFailureHandler.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/infra/handler/CustomLoginFailureHandler.java
@@ -3,17 +3,29 @@ package com.grepp.smartwatcha.infra.handler;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
+// Spring Security 로그인 실패 시 동작하는 핸들러
+// 기능:
+// - 로그인 실패 원인을 로그로 기록
+// - 로그인 페이지로 리다이렉트하며 쿼리 파라미터로 오류 표시
+
+@Slf4j
 @Component
 public class CustomLoginFailureHandler implements AuthenticationFailureHandler {
 
+  // 인증 실패 시 실행되는 메서드
   @Override
   public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
       AuthenticationException exception) throws IOException {
-    System.out.println("로그인 실패: " + exception.getMessage());
+
+    // 로그인 실패 사유 로깅
+    log.info("🔒 [로그인 실패] {}", exception.getMessage());
+
+    // 로그인 페이지로 리다이렉트 (에러 플래그 포함)
     response.sendRedirect("/login?error=true");
   }
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/infra/handler/CustomLoginSuccessHandler.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/infra/handler/CustomLoginSuccessHandler.java
@@ -9,13 +9,23 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
+// Spring Security 로그인 성공 시 실행되는 핸들러
+// 기능:
+  // - 로그인한 사용자의 권한(Role)을 확인
+  // - ROLE_ADMIN 이면 관리자 페이지로 리다이렉트
+
 @Component
 public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
 
+  // 로그인 성공 후 실행되는 메서드
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
       Authentication authentication) throws IOException {
+
+    // 로그인한 사용자의 권한 목록
     Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+
+    // ROLE_ADMIN 권한이 있는 경우 관리자 페이지로 리다이렉트
     for(GrantedAuthority authority : authorities) {
       if(authority.getAuthority().equals("ROLE_ADMIN")) {
         response.sendRedirect("/admin");
@@ -23,6 +33,7 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
       }
     }
 
+    // 일반 유저는 홈 페이지로 이동
     response.sendRedirect("/");
   }
 }


### PR DESCRIPTION
## 📌 과제 설명
Spring Security 설정 및 인증 처리 관련 클래스에 주석을 추가하여 이해도를 높이고, 일부 핸들러의 로그 처리 및 예외 처리 방식을 개선하였습니다.

## 👩‍💻 요구 사항과 구현 내용

### ✅ 커밋별 구현 내역
- `docs: Spring Security 설정 관련 클래스에 설명 주석 추가`
  - `SecurityConfig`, `CustomAccessDeniedHandler`, `CustomLoginSuccessHandler`, `CustomUserDetails` 클래스에 주석 추가

- `refactor: CustomLoginFailureHandler 로그 출력 방식 log로 변경 및 설명 주석 추가`
  - 기존 `System.out.println` → `log.warn()`으로 변경하여 운영 환경에 맞게 조정
  - 실패 사유에 대한 로그 포맷 개선 및 위치 명확히 주석

- `refactor: CustomUserDetailsService 예외를 UsernameNotFoundException → CommonException으로 변경`
  - 에러 상황에 대한 통합된 예외 핸들링을 위해 `CommonException`으로 일원화
  - 관련 설명 주석 추가

## ✅ PR 피드백 및 개선사항
- 로그 레벨을 `info`로 변경했습니다.

## ✅ PR 포인트 & 궁금한 점
- 기존 PR이 다른분들것과 섞여 Close후 다시 PR 올립니다.

