### PR TITLE
refactor: 관리자 대시보드 중복 제거 및 주석 추가 리팩토링(Feature/0520)

### DIFF
--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/AdminDashboardJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/AdminDashboardJpaService.java
@@ -20,42 +20,42 @@ public class AdminDashboardJpaService {
   private final AdminTagJpaRepository adminTagJpaRepository;
   private final UpcomingMovieSyncTimeJpaRepository upcomingMovieSyncTimeJpaRepository;
 
-  public long getTotalUsers() {
+  public long getTotalUsers() { // 전체 유저 수 반환
     return adminUserJpaRepository.count();
   }
 
-  public long getActiveUsers() {
+  public long getActiveUsers() { // 활성 유저 수 반환
     return adminUserJpaRepository.countByActivatedTrue();
   }
 
-  public long getInactiveUsers() {
+  public long getInactiveUsers() { // 비활성 유저 수 반환
     return adminUserJpaRepository.countByActivatedFalse();
   }
 
-  public long getTotalMovies() {
+  public long getTotalMovies() { // 전체 영화 수 반환
     return adminMovieJpaRepository.count();
   }
 
-  public long getUpcomingMovies() {
+  public long getUpcomingMovies() { // 현재 시점 이후 공개 예정 영화 수 반환
     return adminMovieJpaRepository.countByReleaseDateAfter(LocalDateTime.now());
   }
 
-  public List<MovieEntity> getRecentUpcomingMovies() {
+  public List<MovieEntity> getRecentUpcomingMovies() { // 최근 등록된 공개 예정작 5개 반환
     return adminMovieJpaRepository
         .findTop5ByReleaseDateAfterOrderByReleaseDateAsc(LocalDateTime.now());
   }
 
-  public long getTotalTags() {
+  public long getTotalTags() { // 전체 태그 수 반환
     return adminTagJpaRepository.count();
   }
 
-  public int getNewlyAddedMovieCount() {
+  public int getNewlyAddedMovieCount() { // 최근 동기화에서 새로 추가된 영화 수 반환
     return upcomingMovieSyncTimeJpaRepository.findTopByTypeOrderBySyncTimeDesc("upcoming")
         .map(SyncTimeEntity::getNewlyAddedCount)
         .orElse(0);
   }
 
-  public int getFailedSyncCount() {
+  public int getFailedSyncCount() { // 최근 동기화에서 실패한 영화 수 반환
     return upcomingMovieSyncTimeJpaRepository.findTopByTypeOrderBySyncTimeDesc("upcoming")
         .map(SyncTimeEntity::getFailedCount)
         .orElse(0);

--- a/backend/src/main/java/com/grepp/smartwatcha/infra/jpa/entity/SyncTimeEntity.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/infra/jpa/entity/SyncTimeEntity.java
@@ -18,16 +18,17 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 @Entity
+// 공개 예정작 동기화 작업의 시간 및 결과 통계 정보를 저장하는 엔티티
 public class SyncTimeEntity {
   @Id
-  private String type;
+  private String type; // 동기화 종류('upcoming')
 
-  private LocalDateTime syncTime;
+  private LocalDateTime syncTime; // 동기화 시각
 
-  private int newlyAddedCount;
+  private int newlyAddedCount; // 새로 추가된 항목 수
 
-  private int failedCount;
+  private int failedCount; // 동기화 실패 수
 
   @Column(nullable = false)
-  private int enrichFailedCount;
+  private int enrichFailedCount; // enrich 단계 실패 수
 }

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -99,7 +99,7 @@
     <div class="flex-two-column">
         <div class="half-section" style="flex: 0 0 50%;">
             <h5>🕒 Recent Upcoming Sync</h5>
-            <p>📅 Last Sync Time: <span th:text="${#temporals.format(lastSyncTime, 'yyyy-MM-dd HH:mm:ss')}">N/A</span></p>
+            <p>📅 Last Sync Time: <span th:text="${lastSyncTime}">N/A</span></p>
             <p>📥 New Movies Added: <strong th:text="${newlyAddedCount}">0</strong></p>
             <p>
                 ⚠️ Failed:
@@ -136,18 +136,18 @@
                                 <div style="flex: 1; margin-top: 0px">
                                     <p><strong>ID:</strong> <span th:text="${movie.id}">N/A</span></p>
                                     <p><strong>Release Date:</strong>
-                                        <span th:text="${movie.releaseDate != null} ? ${#temporals.format(movie.releaseDate, 'yyyy-MM-dd')} : 'null'">null</span>
+                                        <span th:text="${movie.releaseDate != null ? #temporals.format(movie.releaseDate, 'yyyy-MM-dd') : 'null'}">null</span>
                                     </p>
                                     <p><strong>Certification:</strong>
-                                        <span th:text="${movie.certification != null} ? ${movie.certification} : 'null'">null</span>
+                                        <span th:text="${movie.certification != null ? movie.certification : 'null'}">null</span>
                                     </p>
                                     <p><strong>Country:</strong>
-                                        <span th:text="${movie.country != null} ? ${movie.country} : 'null'">null</span>
+                                        <span th:text="${movie.country != null ? movie.country : 'null'}">null</span>
                                     </p>
                                 </div>
                             </div>
                             <p><strong>Overview:</strong>
-                                <span th:text="${movie.overview != null} ? ${movie.overview} : 'null'">null</span>
+                                <span th:text="${movie.overview != null ? movie.overview : 'null'}">null</span>
                             </p>
                         </div>
                         <div class="modal-footer" style="background-color: #1e1e1e">
@@ -172,31 +172,39 @@
         </div>
     </div>
 
-<script>
-    document.addEventListener('DOMContentLoaded', function () {
-        var elems = document.querySelectorAll('.modal');
-        M.Modal.init(elems);
-    });
-
-    function syncUpcomingMovies() {
-        fetch('/admin/movies/upcoming/sync-manual-test', {
-            method: 'GET'
-        })
-        .then(res => {
-            console.log("응답 상태:", res.status);
-            if (res.ok) {
-                alert("✅ Sync completed successfully!");
-                window.location.href = '/admin/movies/upcoming?v=' + new Date().getTime();
-            } else {
-                alert("❌ Sync failed! (" + res.status + ")");
-            }
-        })
-        .catch(err => {
-            console.error(err);
-            alert("⚠️ An error occurred!");
+    <script>
+        // 페이지가 완전히 로딩된 후 실행될 초기화 코드
+        document.addEventListener('DOMContentLoaded', function () {
+            // 모든 .modal 클래스를 가진 요소를 찾아서 Materialize 모달로 초기화
+            var elems = document.querySelectorAll('.modal');
+            M.Modal.init(elems);
         });
-    }
-</script>
+
+        // "Manual Sync" 버튼 클릭 시 실행될 함수
+        function syncUpcomingMovies() {
+            // 비동기 GET 요청: 수동 동기화 API 호출
+            fetch('/admin/movies/upcoming/sync-manual-test', {
+                method: 'GET'
+            })
+            .then(res => {
+                console.log("응답 상태:", res.status); // 응답 상태 코드 출력
+
+                if (res.ok) {
+                    // 200 OK 응답이면 알림 후 페이지 리로드 (캐시 방지를 위한 타임스탬프 추가)
+                    alert("✅ Sync completed successfully!");
+                    window.location.href = '/admin/movies/upcoming?v=' + new Date().getTime();
+                } else {
+                    // 4xx, 5xx 에러 처리
+                    alert("❌ Sync failed! (" + res.status + ")");
+                }
+            })
+            .catch(err => {
+                // 네트워크 오류 등 예외 발생 시 처리
+                console.error(err);
+                alert("⚠️ An error occurred!");
+            });
+        }
+    </script>
 </section>
 </body>
 </html>


### PR DESCRIPTION
## 📌 과제 설명
관리자 대시보드(AdminController)의 코드 중복을 제거하고, 관련 서비스 및 엔티티 클래스에 설명 주석을 추가했습니다.

## 👩‍💻 요구 사항과 구현 내용
- refactor: 관리자 대시보드 뷰 및 서비스 로직 중복 제거
  - 동기화 시간 및 통계 처리 코드 간결화 (`SyncTimeEntity` null 처리 및 조건 분기 통합)
  - HTML 템플릿(dashboard.html)도 변경된 모델 키에 맞춰 수정

- comment: SyncTimeEntity에 동기화 타입 및 필드 설명 주석 추가
- comment: AdminDashboardJpaService에 각 메서드 용도 설명 주석 추가

## ✅ PR 포인트 & 궁금한 점
- 동기화 통계 정보 처리 방식 리팩토링이 직관적인지 확인 부탁드립니다.