### PR TITLE
fix: 영화 상세 페이지 접근 권한 설정 개선

### DIFF
--- a/backend/src/main/java/com/grepp/smartwatcha/infra/config/SecurityConfig.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/infra/config/SecurityConfig.java
@@ -97,9 +97,13 @@ public class SecurityConfig {
                     "/user/find-password",
                     "/user/find-password/send-code",
                     "/user/find-password/verify",
+                    "/movies/**",           // 영화 관련 페이지 접근 허용
+                    "/recommend/**",        // 추천 관련 페이지 접근 허용
                     "/css/**",
                     "/js/**",
                     "/images/**",
+                    "/fonts/**",           // 폰트 파일 접근 허용
+                    "/webjars/**",         // WebJars 리소스 접근 허용
                     "/error"
                 ).permitAll()                // 인증 없이 접근 가능
                 .anyRequest().authenticated() // 그 외 요청은 인증 필요


### PR DESCRIPTION
✅ 피드백 반영사항
- 영화 관련 페이지(/movies/**) 접근 허용
- 추천 시스템 페이지(/recommend/**) 접근 허용
- 정적 리소스 접근 경로 확장
  - /fonts/** 추가
  - /webjars/** 추가

비로그인 사용자도 영화 상세 페이지와 추천 페이지를 볼 수 있도록 SecurityConfig의 인증 설정을 수정했습니다.