### PR TITLE
feat(admin): 유저 평가 목록 및 상세 모달에 태그 정보 포함(Feature/0523)

### DIFF
--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/dto/AdminRatingDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/dto/AdminRatingDto.java
@@ -1,6 +1,7 @@
 package com.grepp.smartwatcha.app.model.admin.user.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,8 +14,10 @@ import lombok.NoArgsConstructor;
 // Admin User Ratings 페이지 보여줄 때 사용되는 DTO
 // 사용 위치: /admin/users/ratings (유저 평가 전체 조회 페이지)
 public class AdminRatingDto {
+  private Long movieId; // + 영화 아이디
   private String title;
   private Double score;
   private LocalDateTime createdAt;
   private String userName;
+  private List<String> tags; // + 사용자 태그 목록
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/dto/AdminSimpleRatingDto.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/dto/AdminSimpleRatingDto.java
@@ -1,6 +1,7 @@
 package com.grepp.smartwatcha.app.model.admin.user.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +17,9 @@ import lombok.Setter;
 // 사용 위치: /admin/users (회원 목록 페이지)
 // 각 유저의 상세 모달에서 최근 평가 최대 8건 등 간략히 보여줄 때 사용
 public class AdminSimpleRatingDto {
+  private Long movieId; // + 영화 아이디
   private String title;
   private Double score;
   private LocalDateTime createdAt;
+  private List<String> tags; // + 사용자 태그 목록
 }

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/repository/AdminUserTagJpaRepository.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/repository/AdminUserTagJpaRepository.java
@@ -1,0 +1,10 @@
+package com.grepp.smartwatcha.app.model.admin.user.repository;
+
+import com.grepp.smartwatcha.infra.jpa.entity.MovieTagEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminUserTagJpaRepository extends JpaRepository<MovieTagEntity, Long> {
+  // 특정 유저가 특정 영화에 부여한 태그 리스트 조회
+  List<MovieTagEntity> findByUserIdAndMovieId(Long userId, Long movieId);
+}

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/service/AdminUserRatingJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/service/AdminUserRatingJpaService.java
@@ -30,7 +30,7 @@ public class AdminUserRatingJpaService {
     return ratingPage.map(this::toDto);
   }
 
-  // RatingEntity 를 AdminRatingDto 로 변환
+  // RatingEntity → AdminRatingDto 로 변환
   private AdminRatingDto toDto(RatingEntity rating) {
     Long userId = rating.getUser().getId();
     Long movieId = rating.getMovie().getId();

--- a/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/service/AdminUserRatingJpaService.java
+++ b/backend/src/main/java/com/grepp/smartwatcha/app/model/admin/user/service/AdminUserRatingJpaService.java
@@ -2,7 +2,10 @@ package com.grepp.smartwatcha.app.model.admin.user.service;
 
 import com.grepp.smartwatcha.app.model.admin.user.dto.AdminRatingDto;
 import com.grepp.smartwatcha.app.model.admin.user.repository.AdminUserRatingJpaRepository;
+import com.grepp.smartwatcha.app.model.admin.user.repository.AdminUserTagJpaRepository;
 import com.grepp.smartwatcha.infra.jpa.entity.RatingEntity;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminUserRatingJpaService {
 
   private final AdminUserRatingJpaRepository ratingRepository;
+  private final AdminUserTagJpaRepository tagRepository;
 
   // 특정 유저의 평가 목록을 조회하거나, userId가 없을 경우 전체 유저의 평가 목록을 조회
   public Page<AdminRatingDto> getRatings(Long userId, Pageable pageable) {
@@ -28,11 +32,22 @@ public class AdminUserRatingJpaService {
 
   // RatingEntity 를 AdminRatingDto 로 변환
   private AdminRatingDto toDto(RatingEntity rating) {
+    Long userId = rating.getUser().getId();
+    Long movieId = rating.getMovie().getId();
+
+    List<String> tagNames = tagRepository
+        .findByUserIdAndMovieId(userId, movieId)
+        .stream()
+        .map(mt -> mt.getTag().getName())
+        .collect(Collectors.toList());
+
     return AdminRatingDto.builder()
+        .movieId(movieId)
         .title(rating.getMovie().getTitle())
         .score(rating.getScore())
         .createdAt(rating.getCreatedAt())
         .userName(rating.getUser().getName())
+        .tags(tagNames)
         .build();
   }
 }

--- a/backend/src/main/resources/templates/admin/user/list.html
+++ b/backend/src/main/resources/templates/admin/user/list.html
@@ -257,16 +257,27 @@
                 <table>
                   <thead class="grey darken-3 white-text">
                   <tr>
+                    <th style="color: white;">Movie ID</th>
                     <th style="color: white;">Title</th>
-                    <th style="color: white;">Rating</th>
                     <th style="color: white;">Date</th>
+                    <th style="color: white;">Tag</th>
+                    <th style="color: white;">Rating</th>
                   </tr>
                   </thead>
                   <tbody>
                   <tr th:each="rating : ${user.recentRatings}">
+                    <td style="color: white;" th:text="${rating.movieId}">Movie ID</td>
                     <td style="color: white;" th:text="${rating.title}">Movie Title</td>
-                    <td style="color: white;"th:text="${rating.score + ' ★'}">4.5 ★</td>
                     <td style="color: white;" th:text="${#temporals.format(rating.createdAt, 'yyyy-MM-dd')}">2025-01-01</td>
+                    <td>
+                      <!-- 태그가 하나라도 있을 때 -->
+                      <span th:if="${rating.tags != null and !rating.tags.isEmpty()}"
+                            th:text="${#strings.arrayJoin(rating.tags, ', ')}">funny, action</span>
+
+                      <!-- 태그가 없거나 null일 때 -->
+                      <span th:if="${rating.tags == null or rating.tags.isEmpty()}"> x </span>
+                    </td>
+                    <td style="color: white;"th:text="${rating.score + ' ★'}">4.5 ★</td>
                   </tr>
                   <tr th:if="${#lists.isEmpty(user.recentRatings)}">
                     <td colspan="3">No ratings found.</td>

--- a/backend/src/main/resources/templates/admin/user/ratings.html
+++ b/backend/src/main/resources/templates/admin/user/ratings.html
@@ -192,18 +192,29 @@
       <table class="highlight">
         <thead>
         <tr>
+          <th>Movie ID</th>
           <th>User</th>
           <th>Title</th>
-          <th>Rating</th>
           <th>Date</th>
+          <th>Tag</th>
+          <th>Rating</th>
         </tr>
         </thead>
         <tbody>
         <tr th:each="rating : ${pageResponse.content}">
+          <td th:text="${rating.movieId}">Movie Id</td>
           <td th:text="${rating.userName}">User</td>
           <td th:text="${rating.title}">Movie Title</td>
-          <td th:text="${rating.score + ' ★'}">4.5 ★</td>
           <td th:text="${#temporals.format(rating.createdAt, 'yyyy-MM-dd')}">2025-05-01</td>
+          <td>
+            <!-- 태그가 하나라도 있을 때 -->
+            <span th:if="${rating.tags != null and !rating.tags.isEmpty()}"
+                  th:text="${#strings.arrayJoin(rating.tags, ', ')}">funny, action</span>
+
+            <!-- 태그가 없거나 null일 때 -->
+            <span th:if="${rating.tags == null or rating.tags.isEmpty()}"> x </span>
+          </td>
+          <td th:text="${rating.score + ' ★'}">4.5 ★</td>
         </tr>
 
         <tr th:if="${#lists.isEmpty(pageResponse.content)}">


### PR DESCRIPTION
## 📌 과제 설명  
관리자 페이지에서 유저의 평가(Rating) 정보에 해당 유저가 직접 등록한 태그 정보도 함께 출력되도록 기능을 개선하였습니다.  
**유저 상세 모달**, **User Ratings List**(전체 평가 목록) 양쪽에서 태그 정보를 확인할 수 있습니다.

## 👩‍💻 요구 사항과 구현 내용  

- `AdminSimpleRatingDto` 및 `AdminRatingDto`에 `tags: List<String>` 및 `movieId` 필드 추가
- `AdminUserJpaService#getRecentRatings()`에서 유저+영화 기준으로 태그를 함께 조회하여 DTO에 포함
- `AdminUserRatingJpaService#toDto()`에서 평가별 태그도 함께 조회하여 `AdminRatingDto`에 포함
- `AdminUserTagJpaRepository` 생성 및 `findByUserIdAndMovieId()` 메서드로 태그 리스트 조회
- `list.html`(유저 상세 모달), `ratings.html`(User Ratings List) 둘 다에 태그 출력 추가
- 태그가 없을 경우 `"x"`로 표시

## ✅ PR 포인트 & 궁금한 점  
- 커밋 메시지 실수로 인해 `AdminUserRatingJpaService` 커밋을 두번했습니다ㅠ
